### PR TITLE
6 chown chgrp

### DIFF
--- a/.github/build
+++ b/.github/build
@@ -8,7 +8,7 @@ D=$(pwd)
 #
 # We build on multiple platforms/archs
 #
-BUILD_PLATFORMS="linux darwin freebsd"
+BUILD_PLATFORMS="linux darwin freebsd windows"
 BUILD_ARCHS="amd64 386"
 
 # For each platform

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Once installed you can then execute it with the path of one or more rule-files l
 marionette ./rules.txt ./rules2.txt ... ./rulesN.txt
 ```
 
-* **NOTE**: I expect this code to run upon any Unix-like system, however there are things that are known to not work upon Windows.
 
 
 
@@ -119,6 +118,8 @@ The difference in these two approaches is how often things run:
 You'll note that any module which is followed by the token `triggered` will __only__ be executed when it is triggered by name.  If there is no `notify` key referring to that rule it will __never__ be executed.
 
 
+
+
 # Module Types
 
 We have a small number of primitives at the moment implemented in 100% pure golang.  Adding [new modules as plugins](#adding-modules) is possible, and contributions for various purposes are most welcome.
@@ -162,6 +163,7 @@ dpkg { name => "Remove stuff",
 Only the `package` key is required.
 
 In the future we _might_ have an `apt` module for installing new packages.  We'll see.
+
 
 
 ## `edit`
@@ -248,6 +250,7 @@ notification if either:
 * The repository was updated.  (i.e. Remote changes were pulled in.)
 
 
+
 ## `link`
 
 The `link` module allows you to create a symbolic link.
@@ -265,6 +268,7 @@ Valid parameters are:
 * `source` is a mandatory parameter, and specifies the item the symlink should point to.
 
 
+
 ## `shell`
 
 The shell module allows you to run shell-commands.
@@ -277,6 +281,7 @@ shell { name => "I touch your file.",
 ```
 
 `command` is the only mandatory parameter.
+
 
 
 
@@ -304,6 +309,7 @@ A non-zero return code will be assumed to mean something failed, and execution w
 
 
 
+
 # Example Rules
 
 There is an example ruleset included in the distribution:
@@ -311,6 +317,8 @@ There is an example ruleset included in the distribution:
 * [input.txt](input.txt)
 
 That should be safe to run for all users, as it only modifies files beneath `/tmp`.
+
+
 
 
 # Future Plans
@@ -322,6 +330,8 @@ That should be safe to run for all users, as it only modifies files beneath `/tm
   * I guess we could write something like this:
     * `only_if => "${distribution} == Debian"`
     * But of course that gets messy.  Compare with Ansible, again.
+
+
 
 
 ## Github Setup

--- a/file/file_chown_unix.go
+++ b/file/file_chown_unix.go
@@ -1,0 +1,83 @@
+// +build !windows
+
+package file
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+// ChangeOwner changes the owner of the given file/directory to
+// the specified value.
+//
+// If the ownership was changed this function will return true.
+//
+func ChangeOwner(path string, owner string) (bool, error) {
+
+	// Get the details of the file, so we can see if we need
+	// to change owner, group, and mode.
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+
+	// Get the user-details of who we should change to.
+	var data *user.User
+	data, err = user.Lookup(owner)
+	if err != nil {
+		return false, err
+	}
+
+	// Existing values
+	UID := int(info.Sys().(*syscall.Stat_t).Uid)
+	GID := int(info.Sys().(*syscall.Stat_t).Gid)
+
+	// proposed owner
+	uid, _ := strconv.Atoi(data.Uid)
+
+	if uid != UID {
+		err = os.Chown(path, uid, GID)
+		return true, err
+	}
+
+	return false, nil
+}
+
+// ChangeGroup changes the group of the given file/directory to
+// the specified value.
+//
+// If the ownership was changed this function will return true.
+//
+func ChangeGroup(path string, group string) (bool, error) {
+
+	// Get the details of the file, so we can see if we need
+	// to change owner, group, and mode.
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+
+	// Get the user-details of who we should change to.
+	var data *user.User
+	data, err = user.Lookup(group)
+	if err != nil {
+		return false, err
+	}
+
+	// Existing values
+	UID := int(info.Sys().(*syscall.Stat_t).Uid)
+	GID := int(info.Sys().(*syscall.Stat_t).Gid)
+
+	// proposed owner
+	gid, _ := strconv.Atoi(data.Gid)
+
+	if gid != GID {
+		err = os.Chown(path, UID, gid)
+
+		return true, err
+	}
+
+	return false, nil
+}

--- a/file/file_chown_unix.go
+++ b/file/file_chown_unix.go
@@ -9,6 +9,37 @@ import (
 	"syscall"
 )
 
+// ChangeMode changes the mode of the given file/directory to the
+// specified value.
+//
+// If the mode was changed, this function will return true.
+func ChangeMode(path string, mode string) (bool, error) {
+
+	// Get the mode as an integer.
+	//
+	// NOTE: We expect octal input.
+	m, _ := strconv.ParseInt(mode, 8, 64)
+
+	// Get the details of the file, so we can see if we need
+	// to change owner, group, and mode.
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+
+	// If the mode doesn't match what we expect then change it
+	if info.Mode().Perm() != os.FileMode(m) {
+		err = os.Chmod(path, os.FileMode(m))
+		if err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // ChangeOwner changes the owner of the given file/directory to
 // the specified value.
 //

--- a/file/file_chown_windows.go
+++ b/file/file_chown_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package file
+
+// ChangeOwner is a NOP on Microsoft Windows.
+func ChangeOwner(path string, group string) (bool, error) {
+	return false, nil
+}
+
+// ChangeGroup is a NOP on Microsoft Windows.
+func ChangeGroup(path string, group string) (bool, error) {
+	return false, nil
+}

--- a/file/file_chown_windows.go
+++ b/file/file_chown_windows.go
@@ -2,6 +2,11 @@
 
 package file
 
+// ChangeMode is a NOP on Microsoft Windows
+func ChangeMode(path string, mode string) (bool, error) {
+	return false, nil
+}
+
 // ChangeOwner is a NOP on Microsoft Windows.
 func ChangeOwner(path string, group string) (bool, error) {
 	return false, nil


### PR DESCRIPTION
Moved the implementation of some file-primitives to our common/shared library:

* Changing file owner.
* Changing file group.
* Changing file mode.

These were both used in the file & directory modules, and now they've been moved we can create a stub implementation for Microsoft Windows, allowing us to build upon that platform too.

This closes #6.