### PR TITLE
13 backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 * [marionette](#marionette)
 * [Installation &amp; Usage](#installation--usage)
 * [Rule Definition](#rule-definition)
+  * [Command Execution](#command-execution)
   * [Conditionals](#conditionals)
 * [Module Types](#module-types)
    * [directory](#directory)
@@ -152,6 +153,7 @@ file { name    => "set-todays-date",
        target  => "/tmp/today",
        content => `/bin/date ${fmt}` }
 ```
+
 
 
 ## Conditionals

--- a/README.md
+++ b/README.md
@@ -121,6 +121,39 @@ You'll note that any module which is followed by the token `triggered` will __on
 
 
 
+## Command Execution
+
+Backticks can be used to execute commands, inline.  For example we might
+determine the system architecture like this:
+
+```
+let arch = `/usr/bin/arch`
+
+shell { name => "Show arch",
+        command = "echo We are running on an ${arch} system" }
+```
+
+Here `${arch}` expands to the output of the command, as you would expect.
+
+It is also possible to use backticks for any parameter value.  Here we'll
+write the current date to a file:
+
+```
+file { name    => "set-todays-date",
+       target  => "/tmp/today",
+       content => `/usr/bin/date` }
+```
+
+The commands executed with the backticks have any embedded variables expanded _before_ they run, so this works as you'd expect:
+
+```
+let fmt = "+%Y"
+file { name    => "set-todays-date",
+       target  => "/tmp/today",
+       content => `/bin/date ${fmt}` }
+```
+
+
 ## Conditionals
 
 We have some simple support for conditional-execution of rules, via the

--- a/input.txt
+++ b/input.txt
@@ -14,6 +14,11 @@
 #
 let foo = "bar"
 
+#
+# Variables can also be defined to contain the output of commands.
+#
+let today = `date`
+
 
 #
 # The general form of our rules is something like this:
@@ -48,6 +53,15 @@ let foo = "bar"
 # and that directory is missing then it will be created, and the rule
 # will "notify" any rules which are specified.  Once the directory is
 # present that will no longer occur.
+#
+# Finally there are two more magical keys which are used to make a block
+# conditional:
+#
+#     if:
+#      Only run the block if the statement is true.
+#
+#     unless:
+#      Only run the block if the statement is false.
 #
 
 
@@ -89,11 +103,12 @@ directory { name    => "example-two",
 #
 
 #
-# Right let us now look at the other kind of relationship we can define,
-# which is triggering/notifying other rules when we change.
+# Now look at the other kind of relationship we can define, which is
+# triggering/notifying other rules when we change.
 #
 # First of all we'll define a rule with the special "triggered" marker,
-# this means the rule will NEVER execute UNLESS it is triggered.
+# this means the rule will NEVER execute UNLESS it is triggered explicitly
+# by name.
 #
 
 shell triggered { name    => "test-shell-command",
@@ -122,6 +137,33 @@ I think three lines is enough
 #
 # Future runs will change nothing, unless you remove the input file, or
 # edit it such that it contains the wrong content.
+#
+
+
+#
+#  We'll now demonstrate backtick usage, in two different ways.
+#
+#  Recall at the top of our file we added:
+#
+#      let today = `date`
+#
+#  We can use that variable as you'd expect to write the date to
+# a file
+#
+
+file { name    => "test-variable",
+       target  => "/tmp/today",
+       content => "${today}"
+}
+
+#
+# We could have achieved the same result by using the backtick directly,
+# as the following example demonstrates:
+#
+file { name    => "test-backtick",
+       target  => "/tmp/date.txt",
+       content => `date`
+}
 #
 
 

--- a/input.txt
+++ b/input.txt
@@ -164,7 +164,18 @@ file { name    => "test-backtick",
        target  => "/tmp/date.txt",
        content => `date`
 }
+
 #
+# Finally note that before commands are executed any variables are expanded,
+# to allow this to work as you'd expect:
+#
+let fmt = "+%Y"
+file { name    => "set-todays-date",
+       target  => "/tmp/year",
+       content => `/bin/date ${fmt}`
+}
+
+
 
 
 #

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -65,6 +65,16 @@ func (l *Lexer) NextToken() token.Token {
 	case rune('['):
 		tok.Literal = "["
 		tok.Type = token.LSQUARE
+	case rune('`'):
+		str, err := l.readBacktick()
+
+		if err == nil {
+			tok.Type = token.BACKTICK
+			tok.Literal = str
+		} else {
+			tok.Type = token.ILLEGAL
+			tok.Literal = err.Error()
+		}
 	case rune(']'):
 		tok.Literal = "]"
 		tok.Type = token.RSQUARE
@@ -168,6 +178,24 @@ func (l *Lexer) readString() (string, error) {
 		}
 		out = out + string(l.ch)
 
+	}
+
+	return out, nil
+}
+
+// read a backtick-enquoted string
+func (l *Lexer) readBacktick() (string, error) {
+	out := ""
+
+	for {
+		l.readChar()
+		if l.ch == '`' {
+			break
+		}
+		if l.ch == rune(0) {
+			return "", errors.New("unterminated backtick")
+		}
+		out = out + string(l.ch)
 	}
 
 	return out, nil

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -108,7 +108,7 @@ func (p *Parser) parseVariable() error {
 
 	// assignment only handles strings/command-ouptut
 	if val.Type != token.STRING && val.Type != token.BACKTICK {
-		return fmt.Errorf("unexpected value for variable assignment; expected string or backtick")
+		return fmt.Errorf("unexpected value for variable assignment; expected string or backtick, got %v", val)
 	}
 
 	// replace backtick with the appropriate output

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -4,6 +4,8 @@ package parser
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/skx/marionette/lexer"
 	"github.com/skx/marionette/rules"
@@ -104,8 +106,43 @@ func (p *Parser) parseVariable() error {
 		return fmt.Errorf("unterminated assignment")
 	}
 
+	// assignment only handles strings/command-ouptut
+	if val.Type != token.STRING && val.Type != token.BACKTICK {
+		return fmt.Errorf("unexpected value for variable assignment; expected string or backtick")
+	}
+
+	// replace backtick with the appropriate output
+	if val.Type == token.BACKTICK {
+		out, err := p.runCommand(val.Literal)
+		if err != nil {
+			return fmt.Errorf("error running %s: %s", val.Literal, err.Error())
+		}
+		val.Literal = out
+	}
+
 	p.vars[name.Literal] = val.Literal
 	return nil
+}
+
+// runCommand returns the output of the specified command
+func (p *Parser) runCommand(command string) (string, error) {
+
+	// Build up the thing to run, using a shell so that
+	// we can handle pipes/redirection.
+	toRun := []string{"/bin/bash", "-c", command}
+
+	// Run the command
+	cmd := exec.Command(toRun[0], toRun[1:]...)
+
+	// Get the output
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("error running command '%s' %s", command, err.Error())
+	}
+
+	// Strip trailing newline.
+	ret := strings.TrimSuffix(string(output), "\n")
+	return ret, nil
 }
 
 // parseBlock parses the contents of modules' block.
@@ -168,6 +205,7 @@ func (p *Parser) parseBlock(ty string) (rules.Rule, error) {
 		if err != nil {
 			return r, err
 		}
+
 		r.Params[name] = value
 	}
 
@@ -210,6 +248,17 @@ func (p *Parser) readValue(name string) (interface{}, error) {
 		return os.Expand(t.Literal, mapper), nil
 	}
 
+	// backtick?
+	if t.Type == token.BACKTICK {
+		cmd := os.Expand(t.Literal, mapper)
+
+		out, err := p.runCommand(cmd)
+		if err != nil {
+			return "", fmt.Errorf("error running %s: %s", cmd, err.Error())
+		}
+		return out, nil
+
+	}
 	// array?
 	if t.Type != token.LSQUARE {
 		return nil, fmt.Errorf("not a string or an array for value in block %s", name)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -38,7 +38,7 @@ func TestAssign(t *testing.T) {
 
 	// valid tests
 	valid := []string{`let a = "foo"`,
-		`let a = foo`,
+		"let a = `/bin/ls`",
 	}
 
 	for _, test := range valid {

--- a/token/token.go
+++ b/token/token.go
@@ -13,15 +13,16 @@ type Token struct {
 
 // pre-defined TokenTypes
 const (
-	EOF     = "EOF"
-	IDENT   = "IDENT"
-	ILLEGAL = "ILLEGAL"
-	STRING  = "STRING"
-	COMMA   = ","
-	LSQUARE = "["
-	RSQUARE = "]"
-	LBRACE  = "{"
-	RBRACE  = "}"
-	LASSIGN = "=>"
-	ASSIGN  = "="
+	ASSIGN   = "="
+	BACKTICK = "`"
+	COMMA    = ","
+	EOF      = "EOF"
+	IDENT    = "IDENT"
+	ILLEGAL  = "ILLEGAL"
+	LASSIGN  = "=>"
+	LBRACE   = "{"
+	LSQUARE  = "["
+	RBRACE   = "}"
+	RSQUARE  = "]"
+	STRING   = "STRING"
 )


### PR DESCRIPTION
This pull-request integrates support for command execution, via backticks.

Command-output may be used in variable assignment, or as keys to blocks.

This closes #13.