### PR TITLE
Updated lexer to parse correctly.

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -211,7 +211,7 @@ func (l *Lexer) peekChar() rune {
 
 // determinate ch is identifier or not
 func isIdentifier(ch rune) bool {
-	return !isWhitespace(ch) && !isEmpty(ch)
+	return !isWhitespace(ch) && ch != rune('=') && !isEmpty(ch)
 }
 
 // is white space

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -185,3 +185,30 @@ func TestSpecial(t *testing.T) {
 		}
 	}
 }
+
+// Test15Assignment ensures that bug #15 is resolved
+//    https://github.com/skx/marionette/issues/15
+func Test15Assignment(t *testing.T) {
+	input := `let foo="bar"`
+
+	tests := []struct {
+		expectedType    token.Type
+		expectedLiteral string
+	}{
+		{token.IDENT, "let"},
+		{token.IDENT, "foo"},
+		{token.ASSIGN, "="},
+		{token.STRING, "bar"},
+		{token.EOF, ""},
+	}
+	l := New(input)
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}


### PR DESCRIPTION
This pull request closes #15, by allowing the following input to work as expected:

```
let foo="bar"

shell { name    => "foo" ,
        command => "echo I got '${foo}' as a parameter" }
```

The problem in the past was that we'd lex this as two tokens:

* IDENT: "let"
* IDENT: "foo="bar""

Because we didn't stop parsing the identifier at the `=` statement, only on whitespace.  (So "`let foo = "bar"`" always worked.)

The output is now correct:

```
$ ./marionette ./t.in
Running shell-module rule: foo
I got 'bar' as a parameter
```