### PR TITLE
Allow modules access to (global) configuration structure

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,15 @@
+// Package config holds global options.
+//
+// Options are intended to be set via the command-line flags, and made
+// available to all our plugins.
+package config
+
+// Config holds the state which is set by the main driver, and is
+// made available to all of our plugins.
+type Config struct {
+
+	// Verbose is the only configuration option at the moment,
+	// and controls whether we should be quiet, or noisy, when
+	// processing our rule-files.
+	Verbose bool
+}

--- a/input.txt
+++ b/input.txt
@@ -17,6 +17,8 @@ let foo = "bar"
 #
 # Variables can also be defined to contain the output of commands.
 #
+# NOTE: Any trailing newline will be removed.
+#
 let today = `date`
 
 
@@ -48,7 +50,7 @@ let today = `date`
 #
 #    notify:
 #      Specify either a single rule to trigger, or multiple rules to
-#      trigger, when this rule matches
+#      trigger, when this rule triggers.
 #
 # Triggering in this sense means that the rule resulted in a change to
 # your system.  If you write a rule that says "/tmp/blah" must exist
@@ -60,10 +62,10 @@ let today = `date`
 # conditional:
 #
 #     if:
-#      Only run the block if the statement is true.
+#      Only run the block if the specified expression is true.
 #
 #     unless:
-#      Only run the block if the statement is false.
+#      Only run the block if the specified expression is false.
 #
 
 
@@ -119,7 +121,7 @@ shell triggered { name    => "test-shell-command",
 
 #
 # With that rule defined we can now create a file "/tmp/input" with
-# some fixed content, and explicitly notify the result.
+# some fixed content, and explicitly notify the rule it should run.
 #
 file { name => "test-static-content",
        target => "/tmp/input",
@@ -134,8 +136,8 @@ I think three lines is enough
 #
 #  1. The file /tmp/input.txt should have our fixed content saved to it.
 #
-#  2. The file /tmp/output.txt should have been created, because we run
-#     the shell-command upon it.
+#  2. The file /tmp/output.txt should have been created, because we
+#     notified the "test-shell-command" rule it should run.
 #
 # Future runs will change nothing, unless you remove the input file, or
 # edit it such that it contains the wrong content.
@@ -166,6 +168,7 @@ file { name    => "test-backtick",
        content => `date`
 }
 
+
 #
 # Finally note that before commands are executed any variables are expanded,
 # to allow this to work as you'd expect:
@@ -188,7 +191,8 @@ file { name    => "set-todays-date",
 #
 #   2.  How to declare dependencies.
 #
-#   3.  How to trigger other rules, and keep them from firing unless required.
+#   3.  How to trigger other rules, and keep them from firing unless
+#      notified explicitly.  (Via the use of the `triggered` token.)
 #
 #
 
@@ -212,8 +216,8 @@ file {  name       => "fetch file",
 #
 # Implied since I run as non-root
 #
-#       owner      => "skx",
-#       group      => "skx",
+#       owner      => "${USER}",
+#       group      => "${USER}",
 
         notify     => [ "I count your lines" ],
 }
@@ -231,8 +235,8 @@ file {  name       => "fetch file",
 #   "if" => "equals( \"foo\", \"bar\" )",
 #
 shell { name => "Echo Test",
-        command => "echo I'm alive",
-        unless => exists( /bin/ls ) }
+        command => "echo I'm Unix, probably.",
+        if => exists( /bin/ls ) }
 
 #
 # These are some shell-commands.
@@ -252,25 +256,26 @@ shell { name => "I touch your file.",
 #
 # Create a symlink /tmp/password.txt, pointing to /etc/passwd.
 #
-link { name => "Symlink test",
-       source => "/etc/passwd",  target => "/tmp/password.txt" }
+link { name   => "Symlink test",
+       source => "/etc/passwd",
+       target => "/tmp/password.txt" }
 
 
 #
 # Clone a remote repository to the local system.
 #
-git { path => "/tmp/foot/bar/baz",
+git { path       => "/tmp/foot/bar/baz",
       repository => "https://github.com/src-d/go-git", }
 
 #
 # Copy this file to a new name.
 #
-file { name => "copy input.txt to tmp.txt",
+file { name   => "copy input.txt to tmp.txt",
        source => "input.txt",
        target => "copy.txt" }
 
 #
-# Edit that file-copy to remove any comments, i.e lines prefixed with "#"
+# Edit the copied to remove any comments, i.e lines prefixed with "#".
 #
 edit { name => "drop comments",
        target => "copy.txt",

--- a/main.go
+++ b/main.go
@@ -7,11 +7,12 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/skx/marionette/config"
 	"github.com/skx/marionette/executor"
 	"github.com/skx/marionette/parser"
 )
 
-func runFile(filename string, verbose bool) error {
+func runFile(filename string, cfg *config.Config) error {
 
 	// Read the file contents.
 	data, err := ioutil.ReadFile(filename)
@@ -31,8 +32,8 @@ func runFile(filename string, verbose bool) error {
 	// Now we'll create an executor with the rules
 	ex := executor.New(rules)
 
-	// Set the verbosity
-	ex.SetVerbose(verbose)
+	// Set the configuration options.
+	ex.SetConfig(cfg)
 
 	// Check for broken dependencies
 	err = ex.Check()
@@ -56,6 +57,9 @@ func main() {
 	verbose := flag.Bool("verbose", false, "Be verbose in execution")
 	flag.Parse()
 
+	// Create our configuration object
+	cfg := &config.Config{Verbose: *verbose}
+
 	// Ensure we got at least one recipe to execute.
 	if len(flag.Args()) < 1 {
 		fmt.Printf("Usage %s file1 file2 .. fileN\n", os.Args[0])
@@ -64,7 +68,7 @@ func main() {
 
 	// Process each given file.
 	for _, file := range flag.Args() {
-		err := runFile(file, *verbose)
+		err := runFile(file, cfg)
 		if err != nil {
 			fmt.Printf("Error:%s\n", err.Error())
 			return

--- a/modules/api_glue.go
+++ b/modules/api_glue.go
@@ -1,6 +1,10 @@
 package modules
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/skx/marionette/config"
+)
 
 // This is a map of known modules.
 var handlers = struct {
@@ -9,7 +13,7 @@ var handlers = struct {
 }{m: make(map[string]TestCtor)}
 
 // TestCtor is the signature of a constructor-function.
-type TestCtor func() ModuleAPI
+type TestCtor func(cfg *config.Config) ModuleAPI
 
 // Register records a new module.
 func Register(id string, newfunc TestCtor) {
@@ -20,12 +24,12 @@ func Register(id string, newfunc TestCtor) {
 
 // Lookup is the factory-method which looks up and returns
 // an object of the given type - if possible.
-func Lookup(id string) (a ModuleAPI) {
+func Lookup(id string, cfg *config.Config) (a ModuleAPI) {
 	handlers.RLock()
 	ctor, ok := handlers.m[id]
 	handlers.RUnlock()
 	if ok {
-		a = ctor()
+		a = ctor(cfg)
 	}
 	return
 }

--- a/modules/module_apt.go
+++ b/modules/module_apt.go
@@ -93,12 +93,19 @@ func (am *AptModule) Execute(args map[string]interface{}) (bool, error) {
 		// One package was missing; so we'll install.
 		if !present {
 			installed = false
-			fmt.Printf("Package missing: %s\n", pkg)
+			if am.cfg.Verbose {
+				fmt.Printf("\tPackages not installed: %s\n", pkg)
+			}
+
 		}
 	}
 
 	// Package(s) are installed already.
 	if installed {
+		if am.cfg.Verbose {
+			fmt.Printf("\tPackages installed already: %s\n", strings.Join(packages, ","))
+		}
+
 		return false, nil
 	}
 

--- a/modules/module_apt.go
+++ b/modules/module_apt.go
@@ -5,10 +5,15 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/skx/marionette/config"
 )
 
 // AptModule stores our state
 type AptModule struct {
+
+	// cfg contains our configuration object.
+	cfg *config.Config
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -112,7 +117,7 @@ func (am *AptModule) Execute(args map[string]interface{}) (bool, error) {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("apt", func() ModuleAPI {
-		return &AptModule{}
+	Register("apt", func(cfg *config.Config) ModuleAPI {
+		return &AptModule{cfg: cfg}
 	})
 }

--- a/modules/module_directory.go
+++ b/modules/module_directory.go
@@ -5,11 +5,14 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/skx/marionette/config"
 	"github.com/skx/marionette/file"
 )
 
 // DirectoryModule stores our state
 type DirectoryModule struct {
+	// cfg contains our configuration object.
+	cfg *config.Config
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -120,7 +123,7 @@ func (f *DirectoryModule) Execute(args map[string]interface{}) (bool, error) {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("directory", func() ModuleAPI {
-		return &DirectoryModule{}
+	Register("directory", func(cfg *config.Config) ModuleAPI {
+		return &DirectoryModule{cfg: cfg}
 	})
 }

--- a/modules/module_docker.go
+++ b/modules/module_docker.go
@@ -10,10 +10,14 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/skx/marionette/config"
 )
 
 // DockerModule stores our state
 type DockerModule struct {
+
+	// cfg contains our configuration object.
+	cfg *config.Config
 
 	// Cached list of image-tags we've got available on the local host.
 	Tags []string
@@ -166,7 +170,7 @@ func (dm *DockerModule) Execute(args map[string]interface{}) (bool, error) {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("docker", func() ModuleAPI {
-		return &DockerModule{}
+	Register("docker", func(cfg *config.Config) ModuleAPI {
+		return &DockerModule{cfg: cfg}
 	})
 }

--- a/modules/module_docker.go
+++ b/modules/module_docker.go
@@ -115,8 +115,10 @@ func (dm *DockerModule) installImage(img string) error {
 	//
 	// TODO: Clean this up
 	defer out.Close()
-	io.Copy(os.Stdout, out)
 
+	if dm.cfg.Verbose {
+		io.Copy(os.Stdout, out)
+	}
 	// No error.
 	return nil
 }
@@ -156,6 +158,11 @@ func (dm *DockerModule) Execute(args map[string]interface{}) (bool, error) {
 
 		// Not installed; fetch.
 		if !present || (force == "yes") {
+
+			if dm.cfg.Verbose {
+				fmt.Printf("\tPulling docker image %s\n", img)
+			}
+
 			err := dm.installImage(img)
 			if err != nil {
 				return false, err

--- a/modules/module_dpkg.go
+++ b/modules/module_dpkg.go
@@ -4,10 +4,15 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/skx/marionette/config"
 )
 
 // DPKGModule stores our state
 type DPKGModule struct {
+
+	// cfg contains our configuration object.
+	cfg *config.Config
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -56,7 +61,7 @@ func (f *DPKGModule) Execute(args map[string]interface{}) (bool, error) {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("dpkg", func() ModuleAPI {
-		return &DPKGModule{}
+	Register("dpkg", func(cfg *config.Config) ModuleAPI {
+		return &DPKGModule{cfg: cfg}
 	})
 }

--- a/modules/module_edit.go
+++ b/modules/module_edit.go
@@ -7,11 +7,15 @@ import (
 	"os"
 	"regexp"
 
+	"github.com/skx/marionette/config"
 	"github.com/skx/marionette/file"
 )
 
 // EditModule stores our state.
 type EditModule struct {
+
+	// cfg contains our configuration object.
+	cfg *config.Config
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -186,7 +190,7 @@ func (e *EditModule) RemoveLines(path string, pattern string) (bool, error) {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("edit", func() ModuleAPI {
-		return &EditModule{}
+	Register("edit", func(cfg *config.Config) ModuleAPI {
+		return &EditModule{cfg: cfg}
 	})
 }

--- a/modules/module_file.go
+++ b/modules/module_file.go
@@ -7,11 +7,15 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/skx/marionette/config"
 	"github.com/skx/marionette/file"
 )
 
 // FileModule stores our state
 type FileModule struct {
+
+	// cfg contains our configuration object.
+	cfg *config.Config
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -241,7 +245,7 @@ func (f *FileModule) CreateFile(dst string, content string) (bool, error) {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("file", func() ModuleAPI {
-		return &FileModule{}
+	Register("file", func(cfg *config.Config) ModuleAPI {
+		return &FileModule{cfg: cfg}
 	})
 }

--- a/modules/module_git.go
+++ b/modules/module_git.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	mcfg "github.com/skx/marionette/config"
 	"github.com/skx/marionette/file"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/config"
@@ -13,6 +14,9 @@ import (
 
 // GitModule stores our state
 type GitModule struct {
+
+	// cfg contains our configuration object.
+	cfg *mcfg.Config
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -140,7 +144,7 @@ func (g *GitModule) Execute(args map[string]interface{}) (bool, error) {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("git", func() ModuleAPI {
-		return &GitModule{}
+	Register("git", func(cfg *mcfg.Config) ModuleAPI {
+		return &GitModule{cfg: cfg}
 	})
 }

--- a/modules/module_git.go
+++ b/modules/module_git.go
@@ -59,6 +59,10 @@ func (g *GitModule) Execute(args map[string]interface{}) (bool, error) {
 	tmp := filepath.Join(path, ".git")
 	if !file.Exists(tmp) {
 
+		if g.cfg.Verbose {
+			fmt.Printf("\tRepository not present at destination; cloning\n")
+		}
+
 		// Clone since it is missing.
 		_, err := git.PlainClone(path, false, &git.CloneOptions{
 			URL:      repo,
@@ -136,7 +140,18 @@ func (g *GitModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// If the hashes differ we've updated, and thus changed
 	if ref2.Hash() != ref.Hash() {
+
+		if g.cfg.Verbose {
+			fmt.Printf("\tRepository updated.\n")
+		}
+
 		changed = true
+	} else {
+
+		if g.cfg.Verbose {
+			fmt.Printf("\tNo changes to local repository.\n")
+		}
+
 	}
 
 	return changed, err

--- a/modules/module_link.go
+++ b/modules/module_link.go
@@ -4,11 +4,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/skx/marionette/config"
 	"github.com/skx/marionette/file"
 )
 
 // LinkModule stores our state
 type LinkModule struct {
+
+	// cfg contains our configuration object.
+	cfg *config.Config
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -94,7 +98,7 @@ func (f *LinkModule) Execute(args map[string]interface{}) (bool, error) {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("link", func() ModuleAPI {
-		return &LinkModule{}
+	Register("link", func(cfg *config.Config) ModuleAPI {
+		return &LinkModule{cfg: cfg}
 	})
 }

--- a/modules/module_package.go
+++ b/modules/module_package.go
@@ -1,7 +1,11 @@
 package modules
 
+import "github.com/skx/marionette/config"
+
 // PackageModule stores our state
 type PackageModule struct {
+	// cfg contains our configuration object.
+	cfg *config.Config
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -16,7 +20,7 @@ func (f *PackageModule) Execute(args map[string]interface{}) (bool, error) {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("package", func() ModuleAPI {
-		return &PackageModule{}
+	Register("package", func(cfg *config.Config) ModuleAPI {
+		return &PackageModule{cfg: cfg}
 	})
 }

--- a/modules/module_shell.go
+++ b/modules/module_shell.go
@@ -5,10 +5,15 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/skx/marionette/config"
 )
 
 // ShellModule stores our state
 type ShellModule struct {
+
+	// cfg contains our configuration object.
+	cfg *config.Config
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -61,7 +66,7 @@ func (f *ShellModule) Execute(args map[string]interface{}) (bool, error) {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("shell", func() ModuleAPI {
-		return &ShellModule{}
+	Register("shell", func(cfg *config.Config) ModuleAPI {
+		return &ShellModule{cfg: cfg}
 	})
 }

--- a/modules/module_shell.go
+++ b/modules/module_shell.go
@@ -1,6 +1,7 @@
 package modules
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -37,9 +38,9 @@ func (f *ShellModule) Execute(args map[string]interface{}) (bool, error) {
 		return false, fmt.Errorf("missing 'command' parameter")
 	}
 
-	// If we see redirection we're good
-	if strings.Contains(str, ">") || strings.Contains(str, "<") || strings.Contains(str, "|") {
-		str = "bash -c \"" + str + "\""
+	// Show what we're doing.
+	if f.cfg.Verbose {
+		fmt.Printf("\tExecuting: %s\n", str)
 	}
 
 	// Split on space to execute
@@ -54,8 +55,21 @@ func (f *ShellModule) Execute(args map[string]interface{}) (bool, error) {
 	// Now run
 	cmd := exec.Command(bits[0], bits[1:]...)
 
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
+	// If we're hiding the output we'll write it here.
+	var execOut bytes.Buffer
+	var execErr bytes.Buffer
+
+	// Show to the console if we should
+	if f.cfg.Verbose {
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+	} else {
+		// Otherwise pipe to the buffer, and ignore it.
+		cmd.Stdout = &execOut
+		cmd.Stderr = &execErr
+	}
+
+	// Run the command
 	err := cmd.Run()
 	if err != nil {
 		return false, fmt.Errorf("error running command '%s' %s", str, err.Error())


### PR DESCRIPTION
At the moment we only have one command-line option, `-verbose`, which is used to control how noisy to be when running a rule-file.

However it would be nice if modules could pay attention to that flag as well as our execution-engine.  To allow that we have now defined a structure to hold all global options, and made it available to our plugin/modules.

Once complete this pull-request will close #22.

TODO

* Update the modules to honour the verbose option, appropriately.,