### PR TITLE
New module: fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,10 @@ Here we see that we've used two functions:
   * `unset` is a synonym.
 * `success(string)`
   * Returns true if the command `string` is executed and returns a non-error exit-code (i.e. 0).
+  * Output is discarded, and not captured.
 * `failure(string)`
   * Returns true if the command `string` is executed and returns an error exit-code (i.e. non-zero 0).
+  * Output is discarded, and not captured.
 
 More conditional primitives may be added if they appear to be necessary, or if users request them.
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,26 @@ The following keys are supported:
 
 
 
+## `fail`
+
+The fail-module is designed to terminate processing, if you find a situation where the local
+environment doesn't match your requirements.  For example:
+
+```
+let path = `which useradd`
+
+fail {
+   message => "I can't find a working useradd binary to use",
+   if      => empty(path)
+}
+```
+
+The only parameter supported/used is the `message` value:
+
+* `message` - The message to print before terminating the script.
+
+
+
 ## `file`
 
 The file module allows a file to be created, from a local file, or via a remote HTTP-source.

--- a/input.txt
+++ b/input.txt
@@ -280,3 +280,18 @@ file { name   => "copy input.txt to tmp.txt",
 edit { name => "drop comments",
        target => "copy.txt",
        remove_lines => "^#" }
+
+
+#
+# Create a new user for the local system, "server", unless it already exists.
+#
+# NOTE: The use of `echo` means we don't really run the user-creation, as that
+# would fail unless you ran the script under sudo.
+#
+let user = "server"
+
+shell {
+    name => "Create user: ${user}",
+    command => "echo useradd --system --no-create-home ${user}",
+    unless => success("id ${user}"),
+}

--- a/modules/module_fail.go
+++ b/modules/module_fail.go
@@ -1,0 +1,50 @@
+package modules
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/skx/marionette/config"
+)
+
+// FailModule stores our state.
+type FailModule struct {
+
+	// cfg contains our configuration object.
+	cfg *config.Config
+}
+
+// Check is part of the module-api, and checks arguments.
+func (f *FailModule) Check(args map[string]interface{}) error {
+
+	// Ensure we have a message to abort with.
+	_, ok := args["message"]
+	if !ok {
+		return fmt.Errorf("missing 'message' parameter")
+	}
+
+	return nil
+}
+
+// Execute is part of the module-api, and is invoked to run a rule.
+func (f *FailModule) Execute(args map[string]interface{}) (bool, error) {
+
+	// Get the message
+	str := StringParam(args, "message")
+	if str == "" {
+		return false, fmt.Errorf("missing 'message' parameter")
+	}
+
+	// Show it, and terminate
+	fmt.Fprintf(os.Stderr, "FAIL: %s\n", str)
+	os.Exit(1)
+
+	return true, nil
+}
+
+// init is used to dynamically register our module.
+func init() {
+	Register("fail", func(cfg *config.Config) ModuleAPI {
+		return &FailModule{cfg: cfg}
+	})
+}


### PR DESCRIPTION
The `fail` module allows you to terminate execution if the local environment doesn't match things you expect to be present.

For example:

```
let path = `which useradd`

fail {
   message => "I can't find a working useradd",
   if => empty(path)
}
```