### PR TITLE
Silently swallow semi-colons.

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -1,5 +1,16 @@
 // Package lexer contains a simple lexer for reading an input-string
 // and converting it into a series of tokens.
+//
+// In terms of syntax we're not very complex, so our lexer only needs
+// to care about simple tokens:
+//
+// - Comments
+// - Strings
+// - Some simple characters such as "(", ")", "[", "]", "=>", "=", etc.
+// -
+//
+// We can catch some basic errors in the lexing stage, such as unterminated
+// strings, but the parser is the better place to catch such things.
 package lexer
 
 import (
@@ -49,6 +60,12 @@ func (l *Lexer) NextToken() token.Token {
 	// skip single-line comments
 	if l.ch == rune('#') {
 		l.skipComment()
+		return (l.NextToken())
+	}
+
+	// Semi-colons are skipped.
+	if l.ch == rune(';') {
+		l.readChar()
 		return (l.NextToken())
 	}
 
@@ -207,7 +224,7 @@ func (l *Lexer) readBacktick() (string, error) {
 	return out, nil
 }
 
-// peek character
+// peek ahead at the next character
 func (l *Lexer) peekChar() rune {
 	if l.readPosition >= len(l.characters) {
 		return rune(0)
@@ -215,18 +232,18 @@ func (l *Lexer) peekChar() rune {
 	return l.characters[l.readPosition]
 }
 
-// determinate ch is identifier or not
+// determinate whether the given character is legal within an identifier or not.
 func isIdentifier(ch rune) bool {
 	return !isWhitespace(ch) && ch != rune(',') && ch != rune('(') && ch != rune(')') && ch != rune('=') && !isEmpty(ch)
 
 }
 
-// is white space
+// is the character white space?
 func isWhitespace(ch rune) bool {
 	return ch == rune(' ') || ch == rune('\t') || ch == rune('\n') || ch == rune('\r')
 }
 
-// is empty
+// is the given character empty?
 func isEmpty(ch rune) bool {
 	return rune(0) == ch
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -6,9 +6,29 @@ import (
 	"github.com/skx/marionette/token"
 )
 
+// TestEmpty tests a couple of different empty strings
+func TestEmpty(t *testing.T) {
+	empty := []string{
+		";;;;;;;;;;;;;;;",
+		"",
+		"#!/usr/bin/blah",
+		"#!/usr/bin/blah\n# Comment1\n# Comment2",
+	}
+
+	for _, line := range empty {
+		lexer := New(line)
+		result := lexer.NextToken()
+
+		if result.Type != token.EOF {
+			t.Fatalf("First token of empty input is %v", result)
+		}
+	}
+
+}
+
 // TestAssign tests we can assign something.
 func TestAssign(t *testing.T) {
-	input := `let foo = "steve"`
+	input := `let foo = "steve";`
 
 	tests := []struct {
 		expectedType    token.Type
@@ -84,7 +104,7 @@ func TestComments(t *testing.T) {
 
 // TestShebang skips the shebang
 func TestShebang(t *testing.T) {
-	input := `#!/usr/bin/env deployr
+	input := `#!/usr/bin/env marionette
 "Steve"
 # This is another comment`
 


### PR DESCRIPTION
This pull-request, once complete, will close #41, by allowing semicolons to be used.

We'll silently swallow them, which will prevent the syntax errors which would otherwise be raised.