### PR TITLE
Create/Use an environment package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ include "foo.in"
 include "${prefix}/test.in"
 ```
 
-Dependency resolution will work across modules, as the rule-names use a single global namespace - that might change in the future if it causes surprises.
+Dependency resolution will work across modules, as the rule-names use a single global namespace - that might change in the future if it causes surprises.  Variables defined in files which are included are also available outside their scope.
 
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
   * [Conditionals](#conditionals)
   * [Misc. Features](#misc-features)
     * [Command Execution](#command-execution)
-    * [File Inclusion](#file-inclusion)
+    * [File Inclusion](#include-files)
+    * [Pre-Declared Variables](#pre-declared-variables)
 * [Module Types](#module-types)
    * [directory](#directory)
    * [docker](#docker)
@@ -222,7 +223,7 @@ shell { name    => "Show arch",
         command => "echo We are running on an ${arch} system" }
 ```
 
-Here `${arch}` expands to the output of the command, as you would expect, with any trailing newline removed.
+Here `${arch}` expands to the output of the command, as you would expect, with any trailing newline removed.  Note that `${ARCH}` is available by default, as noted in the [pre-declared variables](#pre-declared-variables) section.
 
 It is also possible to use backticks for any parameter value.  Here we'll write the current date to a file:
 
@@ -258,7 +259,15 @@ Dependency resolution will work across modules, as the rule-names use a single g
 
 
 
+### Pre-Declared Variables
 
+The following variables are available by default:
+
+| Name          | Value                                                 |
+|---------------|-------------------------------------------------------|
+| `${ARCH}`     | The system architecture (as taken from `sys.GOARCH.`) |
+| `${HOSTNAME}` | The hostname of the local system                      |
+| `${OS}`       | The operating system name (as taken from `sys.GOOS`). |
 
 
 # Module Types

--- a/README.md
+++ b/README.md
@@ -265,8 +265,8 @@ The following variables are available by default:
 
 | Name          | Value                                                 |
 |---------------|-------------------------------------------------------|
-| `${ARCH}`     | The system architecture (as taken from `sys.GOARCH.`) |
-| `${HOSTNAME}` | The hostname of the local system                      |
+| `${ARCH}`     | The system architecture (as taken from `sys.GOARCH`). |
+| `${HOSTNAME}` | The hostname of the local system.                     |
 | `${OS}`       | The operating system name (as taken from `sys.GOOS`). |
 
 
@@ -500,6 +500,7 @@ That should be safe to run for all users, as it only modifies files beneath `/tm
 # Future Plans
 
 * Gathering "facts" about the local system, and storing them as variables would be useful.
+  * At the moment we just have a small number of [pre-declared variables](#pre-declared-variables).
 
 
 ## See Also

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -44,3 +44,12 @@ func (e *Environment) Get(key string) (string, bool) {
 	val, ok := e.vars[key]
 	return val, ok
 }
+
+// Variables returns all of variables which have been set, as well as their
+// values.
+//
+// This is only used for the parser test-cases, but that doesn't mean it
+// won't be more generally useful..
+func (e *Environment) Variables() map[string]string {
+	return e.vars
+}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -1,0 +1,46 @@
+// Package environment is used to store and retrieve variables.
+//
+// There is one environment which is shared by the driver and the parser.
+package environment
+
+import (
+	"runtime"
+)
+
+// Environment stores our state
+type Environment struct {
+
+	// The variables we're holding.
+	vars map[string]string
+}
+
+// New returns a new Environment object.
+//
+// The new environment receives some default variable/values, which currently
+// include the architecture of the host system and the operating-system upon
+// which we're running.
+func New() *Environment {
+	// Create a new environment
+	tmp := &Environment{vars: make(map[string]string)}
+
+	// Set some default values
+	tmp.vars["ARCH"] = runtime.GOARCH
+	tmp.vars["OS"] = runtime.GOOS
+
+	return tmp
+}
+
+// Set updates the environment to store the given value against the
+// specified key.
+//
+// Any previously-existing value will be overwritten.
+func (e *Environment) Set(key string, val string) {
+	e.vars[key] = val
+}
+
+// Get retrieves the named value from the environment, along with a boolean
+// value to indicate whether the retrieval was successful.
+func (e *Environment) Get(key string) (string, bool) {
+	val, ok := e.vars[key]
+	return val, ok
+}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -4,6 +4,7 @@
 package environment
 
 import (
+	"os"
 	"runtime"
 )
 
@@ -26,6 +27,14 @@ func New() *Environment {
 	// Set some default values
 	tmp.vars["ARCH"] = runtime.GOARCH
 	tmp.vars["OS"] = runtime.GOOS
+
+	// Hostname
+	host, err := os.Hostname()
+	if err == nil {
+		tmp.vars["HOSTNAME"] = host
+	} else {
+		tmp.vars["HOSTNAME"] = "unknown"
+	}
 
 	return tmp
 }

--- a/environment/environment_test.go
+++ b/environment/environment_test.go
@@ -1,0 +1,66 @@
+package environment
+
+import (
+	"runtime"
+	"testing"
+)
+
+// Test built-in values
+func TestExpected(t *testing.T) {
+
+	x := New()
+
+	a, aOK := x.Get("ARCH")
+	if !aOK {
+		t.Fatalf("Failed to get ${ARCH}")
+	}
+	if a != runtime.GOARCH {
+		t.Fatalf("${ARCH} had wrong value != %s", runtime.GOARCH)
+	}
+
+	o, oOK := x.Get("OS")
+	if !oOK {
+		t.Fatalf("Failed to get ${OS}")
+	}
+	if o != runtime.GOOS {
+		t.Fatalf("${OS} had wrong value != %s", runtime.GOOS)
+	}
+}
+
+// TestSet ensures a value will remain
+func TestSet(t *testing.T) {
+
+	e := New()
+
+	// Confirm getting a missing value fails
+	_, ok := e.Get("STEVE")
+	if ok {
+		t.Fatalf("Got value for STEVE, shouldn't have done")
+	}
+
+	// Set the value
+	e.Set("STEVE", "KEMP")
+
+	// Get it again
+	val := ""
+	val, ok = e.Get("STEVE")
+	if !ok {
+		t.Fatalf("After setting the value wasn't available")
+	}
+	if val != "KEMP" {
+		t.Fatalf("Wrong value retrieved")
+	}
+
+	// Update the value
+	e.Set("STEVE", "STEVE")
+
+	// Get it again
+	val, ok = e.Get("STEVE")
+	if !ok {
+		t.Fatalf("After setting the value wasn't available")
+	}
+	if val != "STEVE" {
+		t.Fatalf("Wrong value retrieved, after update")
+	}
+
+}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/executor"
 	"github.com/skx/marionette/parser"
 )
@@ -20,8 +21,11 @@ func runFile(filename string, cfg *config.Config) error {
 		return err
 	}
 
-	// Create a new parser.
-	p := parser.New(string(data))
+	// Create a new execution environment
+	env := environment.New()
+
+	// Create a new parser, ensuring it uses the new environment.
+	p := parser.NewWithEnvironment(string(data), env)
 
 	// Parse the rules
 	rules, err := p.Parse()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -26,15 +26,24 @@ func TestAssign(t *testing.T) {
 
 	for _, test := range broken {
 
+		// Create a new parser
 		p := New(test)
-		_, err := p.Parse()
 
+		// Count the number of variables which exist in an
+		// empty parser
+		vars := p.e.Variables()
+		vlen := len(vars)
+
+		// Parse the input
+		_, err := p.Parse()
 		if err == nil {
 			t.Errorf("expected error parsing broken assign '%s' - got none", test)
 		}
 
-		v := p.Variables()
-		if len(v) != 0 {
+		// Count the variables which are set,
+		// there should be no increase.
+		v := p.e.Variables()
+		if len(v) != vlen {
 			t.Errorf("unexpected variables present")
 		}
 	}
@@ -46,15 +55,23 @@ func TestAssign(t *testing.T) {
 
 	for _, test := range valid {
 
+		// Create the parser
 		p := New(test)
-		_, err := p.Parse()
 
+		// Count the number of variables which exist in an
+		// empty parser
+		vars := p.e.Variables()
+		vlen := len(vars)
+
+		// Parse
+		_, err := p.Parse()
 		if err != nil {
 			t.Errorf("unexpected error parsing '%s' %s", test, err.Error())
 		}
 
-		v := p.Variables()
-		if len(v) != 1 {
+		// Now we should have one more variable.
+		v := p.e.Variables()
+		if len(v) != (vlen + 1) {
 			t.Errorf("variable not present")
 		}
 	}


### PR DESCRIPTION
This will close #40, by allowing parsed values to be made available from within files that are included.

We do that by creating a dedicated environment package - the parse will use the same instance of that package regardless of whether it is processing a file, or an included file in a sub-parser.

The main driver will instantiate a global one, and that will persist.

We'll also take the opportunity to define `${ARCH}` and `${OS}` globally.