### PR TITLE
Refactor conditional-parsing.

### DIFF
--- a/conditionals/conditionals.go
+++ b/conditionals/conditionals.go
@@ -10,8 +10,32 @@
 package conditionals
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 )
+
+// ConditionCall holds the invokation of a conditional expression.
+//
+// Currently we support a few different types of conditional methods,
+// which can only be used as the values for magical blocks "if" and "unless".
+//
+// New conditional-types can be implemented without touching the parser-code,
+// or even the executor, just defining new self-registering classes in the
+// conditionals package.
+type ConditionCall struct {
+
+	// Name stores the name of the conditional-functions to be called.
+	Name string
+
+	// Args contains the arguments to be used for the function invocation.
+	Args []string
+}
+
+// String converts a ConditionCall to a string.
+func (c ConditionCall) String() string {
+	return fmt.Sprintf("%s(%s)", c.Name, strings.Join(c.Args, ","))
+}
 
 // This is a map of known conditional methods.
 var handlers = struct {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/skx/marionette/conditionals"
 	"github.com/skx/marionette/config"
 	"github.com/skx/marionette/modules"
-	"github.com/skx/marionette/parser"
 	"github.com/skx/marionette/rules"
 )
 
@@ -222,7 +221,7 @@ func (e *Executor) Execute() error {
 func (e *Executor) runConditional(cond interface{}) (bool, error) {
 
 	// Get the value as an instance of our Conditional struct
-	test, ok := cond.(*parser.Condition)
+	test, ok := cond.(*conditionals.ConditionCall)
 	if !ok {
 		return false, fmt.Errorf("we expected a conditional structure, but got %v", cond)
 	}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/skx/marionette/conditionals"
 	"github.com/skx/marionette/config"
-	"github.com/skx/marionette/parser"
 	"github.com/skx/marionette/rules"
 )
 
@@ -208,7 +208,7 @@ func TestIf(t *testing.T) {
 	//
 	params := make(map[string]interface{})
 	params["name"] = "foo"
-	params["if"] = &parser.Condition{Name: "equals",
+	params["if"] = &conditionals.ConditionCall{Name: "equals",
 		Args: []string{"foo", "bar"}}
 
 	//
@@ -251,7 +251,7 @@ func TestIf(t *testing.T) {
 	//
 	// Finally we try to run with an unknown conditional
 	//
-	params["if"] = &parser.Condition{Name: "agrees",
+	params["if"] = &conditionals.ConditionCall{Name: "agrees",
 		Args: []string{"foo", "bar"}}
 	r1[0].Params = params
 	ex = New(r1)
@@ -278,7 +278,7 @@ func TestTriggered(t *testing.T) {
 			Name:      "bob",
 			Triggered: false,
 			Params: map[string]interface{}{"require": "test",
-				"if": &parser.Condition{Name: "equal",
+				"if": &conditionals.ConditionCall{Name: "equal",
 					Args: []string{"foo", "bar"}}},
 		},
 		rules.Rule{Type: "file",
@@ -312,7 +312,7 @@ func TestUnless(t *testing.T) {
 	//
 	params := make(map[string]interface{})
 	params["name"] = "foo"
-	params["unless"] = &parser.Condition{Name: "equals",
+	params["unless"] = &conditionals.ConditionCall{Name: "equals",
 		Args: []string{"bar", "bar"}}
 
 	//
@@ -355,7 +355,7 @@ func TestUnless(t *testing.T) {
 	//
 	// Finally we try to run with an unknown conditional
 	//
-	params["unless"] = &parser.Condition{Name: "agrees",
+	params["unless"] = &conditionals.ConditionCall{Name: "agrees",
 		Args: []string{"foo", "bar"}}
 	r1[0].Params = params
 	ex = New(r1)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -20,32 +20,12 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/skx/marionette/conditionals"
 	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/lexer"
 	"github.com/skx/marionette/rules"
 	"github.com/skx/marionette/token"
 )
-
-// Condition holds the definition of a conditional expression.
-//
-// Currently we support a few different types of conditional methods,
-// which can only be used as the values for magical blocks "if" and "unless".
-//
-// We're flexible enough that new conditional-types can be implemented
-// without touching the parser-code, or even the executor.
-type Condition struct {
-
-	// Name stores the name of the conditional-functions to be called.
-	Name string
-
-	// Args contains the arguments to be used for the function invocation.
-	Args []string
-}
-
-// String converts a Condition to a string.
-func (c Condition) String() string {
-	return fmt.Sprintf("%s(%s)", c.Name, strings.Join(c.Args, ","))
-}
 
 // Parser holds our state.
 type Parser struct {
@@ -456,7 +436,7 @@ func (p *Parser) parseBlock(ty string) (rules.Rule, error) {
 			//
 			// Save those values away in our interface map.
 			//
-			r.Params[name] = &Condition{Name: tType.Literal, Args: args}
+			r.Params[name] = &conditionals.ConditionCall{Name: tType.Literal, Args: args}
 		} else {
 
 			// Now look for "=>"

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/skx/marionette/conditionals"
 )
 
 // TestAssign tests we can assign variables
@@ -202,7 +204,7 @@ func TestConditional(t *testing.T) {
 		t.Errorf("unexpected number of results")
 	}
 
-	res, ok := out[0].Params["if"].(*Condition)
+	res, ok := out[0].Params["if"].(*conditionals.ConditionCall)
 	if !ok {
 		t.Errorf("we didn't parse a conditional")
 	}


### PR DESCRIPTION
Looking over the code in the most recent pull-requests it seems obvious
that the conditional-invokation didn't belong in the
`parser.Conditional` struct.

Moved it to `conditionals.ConditionCall` where it is better named and
placed.

Updated test-cases to match.