### PR TITLE
Remove lines before appending

### DIFF
--- a/modules/module_edit.go
+++ b/modules/module_edit.go
@@ -50,18 +50,6 @@ func (e *EditModule) Execute(args map[string]interface{}) (bool, error) {
 	// Now look at our actions
 	//
 
-	// Append a line if missing
-	append := StringParam(args, "append_if_missing")
-	if append != "" {
-		changed, err := e.Append(target, append)
-		if err != nil {
-			return false, err
-		}
-		if changed {
-			ret = true
-		}
-	}
-
 	// Remove lines matching a regexp.
 	remove := StringParam(args, "remove_lines")
 	if remove != "" {
@@ -70,6 +58,18 @@ func (e *EditModule) Execute(args map[string]interface{}) (bool, error) {
 			return false, err
 		}
 
+		if changed {
+			ret = true
+		}
+	}
+
+	// Append a line if missing
+	append := StringParam(args, "append_if_missing")
+	if append != "" {
+		changed, err := e.Append(target, append)
+		if err != nil {
+			return false, err
+		}
 		if changed {
 			ret = true
 		}


### PR DESCRIPTION
Allow a line to be changed by removing a similar looking line before
appending a new line if missing.

```
let date = `date`
edit {
    target => "example-file",
    remove_lines => "Last edited .*",
    append_if_missing => "Last edited ${date}"
}
```

The diff is slightly noisy but I only flipped the order of the blocks.