### PR TITLE
Remove tempfile after RemoveLines

### DIFF
--- a/modules/module_edit.go
+++ b/modules/module_edit.go
@@ -165,6 +165,7 @@ func (e *EditModule) RemoveLines(path string, pattern string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer os.Remove(tmpfile.Name())
 
 	// Process the input file line by line
 	scanner := bufio.NewScanner(in)


### PR DESCRIPTION
This one location didn't perform cleanup up tempfile's.

There's a few places in tests where `defer` isn't used, and I think there's a chance some files could be leftover from those tests, but they might aid in debugging if the test ends early, so I was inclined to leave them.