### PR TITLE
Remove package exec duplication

### DIFF
--- a/modules/system/packages.go
+++ b/modules/system/packages.go
@@ -190,7 +190,7 @@ func (p *Package) run(run []string) error {
 		if exiterr, ok := err.(*exec.ExitError); ok {
 
 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-				return fmt.Errorf("exit code for '%s' was %d", strings.Join(run, ","), status.ExitStatus())
+				return fmt.Errorf("exit code for '%s' was %d", strings.Join(run, " "), status.ExitStatus())
 			}
 		}
 	}

--- a/modules/system/packages.go
+++ b/modules/system/packages.go
@@ -108,24 +108,8 @@ func (p *Package) Update() error {
 	// Split
 	run := strings.Split(tmp, " ")
 
-	// Run
-	cmd := exec.Command(run[0], run[1:]...)
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
-	// Wait for completion
-	if err := cmd.Wait(); err != nil {
-
-		if exiterr, ok := err.(*exec.ExitError); ok {
-
-			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-				return fmt.Errorf("exit code for '%s' was %d", tmp, status.ExitStatus())
-			}
-		}
-	}
-
-	return nil
+	// Run the command
+	return p.run(run)
 }
 
 // IsInstalled checks a package installed?


### PR DESCRIPTION
Removes a duplicate code block which exec's commands and fixes a small bug where the command strings in an error message would be joined with commas rather than spaces. The original commands are split on spaces.