### PR TITLE
Add USERNAME pre-defined variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ The following variables are available by default:
 | `${ARCH}`     | The system architecture (as taken from `sys.GOARCH`). |
 | `${HOSTNAME}` | The hostname of the local system.                     |
 | `${OS}`       | The operating system name (as taken from `sys.GOOS`). |
+| `${USERNAME}` | The username of user running marionette.              |
 
 
 # Module Types

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -5,6 +5,7 @@ package environment
 
 import (
 	"os"
+	"os/user"
 	"runtime"
 )
 
@@ -35,6 +36,15 @@ func New() *Environment {
 	host, err := os.Hostname()
 	if err == nil {
 		tmp.vars["HOSTNAME"] = host
+	}
+
+	// Default username as empty
+	tmp.vars["USERNAME"] = ""
+
+	// Get the real username, and set it if no errors
+	user, err := user.Current()
+	if err == nil {
+		tmp.vars["USERNAME"] = user.Username
 	}
 
 	return tmp


### PR DESCRIPTION
Adds a simple `${USERNAME}` variable which is set to the username of the user running marionette.

