### PR TITLE
57 include

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -253,25 +253,29 @@ func (e *Executor) executeSingleRule(rule rules.Rule) error {
 	//
 	// Are there conditionals present?
 	//
-	if rule.Params["if"] != nil {
-		res, err := e.runConditional(rule.Params["if"])
-		if err != nil {
-			return err
-		}
-		if !res {
-			e.verbose(fmt.Sprintf("\tSkipping rule condition was not true: %s", rule.Params["if"]))
-			return nil
+	for _, key := range []string{"if", "include_if"} {
+		if rule.Params[key] != nil {
+			res, err := e.runConditional(rule.Params[key])
+			if err != nil {
+				return err
+			}
+			if !res {
+				e.verbose(fmt.Sprintf("\tSkipping rule condition was not true: %s", rule.Params[key]))
+				return nil
+			}
 		}
 	}
 
-	if rule.Params["unless"] != nil {
-		res, err := e.runConditional(rule.Params["unless"])
-		if err != nil {
-			return err
-		}
-		if res {
-			e.verbose(fmt.Sprintf("\tSkipping rule condition was true: %s", rule.Params["unless"]))
-			return nil
+	for _, key := range []string{"unless", "include_unless"} {
+		if rule.Params[key] != nil {
+			res, err := e.runConditional(rule.Params[key])
+			if err != nil {
+				return err
+			}
+			if res {
+				e.verbose(fmt.Sprintf("\tSkipping rule condition was true: %s", rule.Params[key]))
+				return nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Allow conditional inclusions, which closes #57.
    
This pull-request updates the parser to allow an inclusion statement to be followed by a (single) conditional, for example:
    
            include "foo.rules" if     equals(`hostname`, "frodo.local")
            include "foo.rules" unless equals(`hostname`, "sam.local")
    
The way this is implemented is to extend the magical keys we use:
    
* if
  * To allow a rule to run only if the given conditional is true.
* unless
  * To allow a rule to run only if the given conditional is false
    
We now support a secret set of keys `include_if` and `include_unless` which work in the same way.
    
**TODO**    

* See what happens if a rule has an `if` and an `include_if` key.
* It might be this approach is doomed and we have to make `include` a special kind of (runtime) rule.

**Note**

* We had to change the parse to allow looking ahead a single token, without consuming it, to see if an inclusion was followed by an if/unless rule/token.