### PR TITLE
Pass environment to modules

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/skx/marionette/conditionals"
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/modules"
 	"github.com/skx/marionette/rules"
 )
@@ -30,13 +31,16 @@ type Executor struct {
 
 	// cfg holds our configuration options.
 	cfg *config.Config
+
+	// env holds the environment.
+	env *environment.Environment
 }
 
 // New creates a new executor, using a series of rules which should have
 // been discovered by the parser.
-func New(r []rules.Rule) *Executor {
+func New(env *environment.Environment, r []rules.Rule) *Executor {
 
-	e := &Executor{Rules: r}
+	e := &Executor{Rules: r, env: env}
 
 	//
 	// Default configuration
@@ -334,7 +338,7 @@ func (e *Executor) runInternalModule(helper modules.ModuleAPI, rule rules.Rule) 
 	}
 
 	// Run the change
-	changed, err := helper.Execute(rule.Params)
+	changed, err := helper.Execute(e.env, rule.Params)
 	if err != nil {
 		return false, fmt.Errorf("error running %s-module rule '%s' %s",
 			rule.Type, rule.Name, err.Error())

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/skx/marionette/conditionals"
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/rules"
 )
 
@@ -35,6 +36,8 @@ func TestSimpleRule(t *testing.T) {
 	params["target"] = tmpfile.Name()
 	params["content"] = expected
 
+	env := environment.New()
+
 	//
 	// Create a simple rule
 	//
@@ -46,7 +49,7 @@ func TestSimpleRule(t *testing.T) {
 	//
 	// Create the executor
 	//
-	ex := New(r)
+	ex := New(env, r)
 	ex.SetConfig(&config.Config{Verbose: true})
 
 	err = ex.Check()
@@ -81,6 +84,8 @@ func TestCheckFail(t *testing.T) {
 	//
 	params := make(map[string]interface{})
 
+	env := environment.New()
+
 	//
 	// Create a simple rule
 	//
@@ -91,7 +96,7 @@ func TestCheckFail(t *testing.T) {
 	//
 	// Create the executor
 	//
-	ex := New(r)
+	ex := New(env, r)
 	ex.SetConfig(&config.Config{Verbose: true})
 
 	err := ex.Check()
@@ -117,6 +122,8 @@ func TestRepeatedNames(t *testing.T) {
 	//
 	params := make(map[string]interface{})
 
+	env := environment.New()
+
 	//
 	// Create a pair of rules with identical names.
 	//
@@ -133,7 +140,7 @@ func TestRepeatedNames(t *testing.T) {
 	//
 	// Create the executor
 	//
-	ex := New(r)
+	ex := New(env, r)
 	ex.SetConfig(&config.Config{Verbose: true})
 
 	err := ex.Check()
@@ -155,6 +162,8 @@ func TestBrokenDependencies(t *testing.T) {
 	// -> missing rule
 	params["require"] = "foo"
 
+	env := environment.New()
+
 	//
 	// Create a rule with a single dependency
 	//
@@ -174,7 +183,7 @@ func TestBrokenDependencies(t *testing.T) {
 	//
 	// Create the executor
 	//
-	ex := New(r1)
+	ex := New(env, r1)
 	ex.SetConfig(&config.Config{Verbose: true})
 
 	err := ex.Check()
@@ -188,7 +197,7 @@ func TestBrokenDependencies(t *testing.T) {
 	//
 	// Create the executor, again
 	//
-	ex = New(r2)
+	ex = New(env, r2)
 	ex.SetConfig(&config.Config{Verbose: true})
 
 	err = ex.Check()
@@ -211,6 +220,8 @@ func TestIf(t *testing.T) {
 	params["if"] = &conditionals.ConditionCall{Name: "equals",
 		Args: []string{"foo", "bar"}}
 
+	env := environment.New()
+
 	//
 	// Create our rule.
 	//
@@ -222,7 +233,7 @@ func TestIf(t *testing.T) {
 	//
 	// Create the executor
 	//
-	ex := New(r1)
+	ex := New(env, r1)
 	ex.SetConfig(&config.Config{Verbose: true})
 
 	err := ex.Check()
@@ -239,7 +250,7 @@ func TestIf(t *testing.T) {
 	//
 	params["if"] = "foo"
 	r1[0].Params = params
-	ex = New(r1)
+	ex = New(env, r1)
 	err = ex.Execute()
 	if err == nil {
 		t.Errorf("expected error running rules, got none")
@@ -254,7 +265,7 @@ func TestIf(t *testing.T) {
 	params["if"] = &conditionals.ConditionCall{Name: "agrees",
 		Args: []string{"foo", "bar"}}
 	r1[0].Params = params
-	ex = New(r1)
+	ex = New(env, r1)
 	err = ex.Execute()
 	if err == nil {
 		t.Errorf("expected error running rules, got none")
@@ -268,6 +279,8 @@ func TestIf(t *testing.T) {
 // TestTriggered uses a rule which is "triggered", and thus shouldn't be
 // executed normally.
 func TestTriggered(t *testing.T) {
+
+	env := environment.New()
 
 	//
 	// Create our rule.
@@ -290,7 +303,7 @@ func TestTriggered(t *testing.T) {
 	//
 	// Create the executor
 	//
-	ex := New(r1)
+	ex := New(env, r1)
 	ex.SetConfig(&config.Config{Verbose: true})
 
 	err := ex.Check()
@@ -315,6 +328,8 @@ func TestUnless(t *testing.T) {
 	params["unless"] = &conditionals.ConditionCall{Name: "equals",
 		Args: []string{"bar", "bar"}}
 
+	env := environment.New()
+
 	//
 	// Create our rule.
 	//
@@ -326,7 +341,7 @@ func TestUnless(t *testing.T) {
 	//
 	// Create the executor
 	//
-	ex := New(r1)
+	ex := New(env, r1)
 	ex.SetConfig(&config.Config{Verbose: true})
 
 	err := ex.Check()
@@ -343,7 +358,7 @@ func TestUnless(t *testing.T) {
 	//
 	params["unless"] = "foo"
 	r1[0].Params = params
-	ex = New(r1)
+	ex = New(env, r1)
 	err = ex.Execute()
 	if err == nil {
 		t.Errorf("expected error running rules, got none")
@@ -358,7 +373,7 @@ func TestUnless(t *testing.T) {
 	params["unless"] = &conditionals.ConditionCall{Name: "agrees",
 		Args: []string{"foo", "bar"}}
 	r1[0].Params = params
-	ex = New(r1)
+	ex = New(env, r1)
 	err = ex.Execute()
 	if err == nil {
 		t.Errorf("expected error running rules, got none")

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func runFile(filename string, cfg *config.Config) error {
 	}
 
 	// Now we'll create an executor with the rules
-	ex := executor.New(rules)
+	ex := executor.New(env, rules)
 
 	// Set the configuration options.
 	ex.SetConfig(cfg)

--- a/modules/api.go
+++ b/modules/api.go
@@ -3,6 +3,10 @@
 // each accept an arbitrary set of parameters which are module-specific.
 package modules
 
+import (
+	"github.com/skx/marionette/environment"
+)
+
 // ModuleAPI is the interface to which all of our modules must conform.
 //
 // There are only two methods, one to check if the supplied parameters
@@ -20,7 +24,7 @@ type ModuleAPI interface {
 	//
 	// The return value is true if the module made a change
 	// and false otherwise.
-	Execute(map[string]interface{}) (bool, error)
+	Execute(*environment.Environment, map[string]interface{}) (bool, error)
 }
 
 // StringParam returns the named parameter, as a string, from the map.

--- a/modules/module_directory.go
+++ b/modules/module_directory.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/file"
 )
 
@@ -33,7 +34,7 @@ func (f *DirectoryModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *DirectoryModule) Execute(args map[string]interface{}) (bool, error) {
+func (f *DirectoryModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
 	// Default to not having changed
 	changed := false

--- a/modules/module_docker.go
+++ b/modules/module_docker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 )
 
 // DockerModule stores our state
@@ -128,7 +129,7 @@ func (dm *DockerModule) installImage(img string) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (dm *DockerModule) Execute(args map[string]interface{}) (bool, error) {
+func (dm *DockerModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
 	// We might have multiple images to fetch
 	var images []string

--- a/modules/module_edit.go
+++ b/modules/module_edit.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/file"
 )
 
@@ -36,7 +37,7 @@ func (e *EditModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (e *EditModule) Execute(args map[string]interface{}) (bool, error) {
+func (e *EditModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
 	var ret bool
 

--- a/modules/module_edit_test.go
+++ b/modules/module_edit_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/file"
 )
 
@@ -44,6 +45,8 @@ func TestEditCheck(t *testing.T) {
 
 func TestEditAppend(t *testing.T) {
 
+	env := environment.New()
+
 	// create a temporary file
 	tmpfile, err := ioutil.TempFile("", "example")
 	if err != nil {
@@ -60,7 +63,7 @@ func TestEditAppend(t *testing.T) {
 	args["target"] = tmpfile.Name()
 	args["append_if_missing"] = "Steve Kemp"
 
-	changed, err := e.Execute(args)
+	changed, err := e.Execute(env, args)
 	if err != nil {
 		t.Fatalf("error changing file")
 	}
@@ -82,7 +85,7 @@ func TestEditAppend(t *testing.T) {
 	}
 
 	// Call again
-	changed, err = e.Execute(args)
+	changed, err = e.Execute(env, args)
 	if err != nil {
 		t.Fatalf("error changing file")
 	}
@@ -103,7 +106,7 @@ func TestEditAppend(t *testing.T) {
 
 	// Finally append "Test"
 	args["append_if_missing"] = "Test"
-	changed, err = e.Execute(args)
+	changed, err = e.Execute(env, args)
 	if err != nil {
 		t.Fatalf("error changing file")
 	}
@@ -125,6 +128,8 @@ func TestEditAppend(t *testing.T) {
 
 func TestEditRemove(t *testing.T) {
 
+	env := environment.New()
+
 	// create a temporary file
 	tmpfile, err := ioutil.TempFile("", "example")
 	if err != nil {
@@ -145,7 +150,7 @@ func TestEditRemove(t *testing.T) {
 	args["remove_lines"] = "^#"
 
 	// Make the change
-	changed, err := e.Execute(args)
+	changed, err := e.Execute(env, args)
 	if err != nil {
 		t.Fatalf("unexpected error")
 	}
@@ -154,7 +159,7 @@ func TestEditRemove(t *testing.T) {
 	}
 
 	// Second time nothing should happen
-	changed, err = e.Execute(args)
+	changed, err = e.Execute(env, args)
 	if err != nil {
 		t.Fatalf("unexpected error")
 	}
@@ -173,14 +178,14 @@ func TestEditRemove(t *testing.T) {
 
 	// Now test that an invalid regexp is taken
 	args["remove_lines"] = "*"
-	_, err = e.Execute(args)
+	_, err = e.Execute(env, args)
 	if err == nil {
 		t.Fatalf("expected error, got none")
 	}
 
 	// Remove the temporary file, and confirm we get something similar
 	os.Remove(tmpfile.Name())
-	_, err = e.Execute(args)
+	_, err = e.Execute(env, args)
 	if err != nil {
 		t.Fatalf("didn't expect error, got one")
 	}

--- a/modules/module_fail.go
+++ b/modules/module_fail.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 )
 
 // FailModule stores our state.
@@ -33,7 +34,7 @@ func (f *FailModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *FailModule) Execute(args map[string]interface{}) (bool, error) {
+func (f *FailModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
 	// Get the message
 	str := StringParam(args, "message")

--- a/modules/module_fail_test.go
+++ b/modules/module_fail_test.go
@@ -3,6 +3,8 @@ package modules
 import (
 	"strings"
 	"testing"
+
+	"github.com/skx/marionette/environment"
 )
 
 func TestFailCheck(t *testing.T) {
@@ -42,10 +44,12 @@ func TestFail(t *testing.T) {
 
 	f := &FailModule{}
 
+	env := environment.New()
+
 	// Setup params
 	args := make(map[string]interface{})
 
-	changed, err := f.Execute(args)
+	changed, err := f.Execute(env, args)
 	if err == nil {
 		t.Fatalf("expected error, got none")
 	}
@@ -59,7 +63,7 @@ func TestFail(t *testing.T) {
 	// Setup a message
 	args["message"] = "I have no cake"
 
-	changed, err = f.Execute(args)
+	changed, err = f.Execute(env, args)
 	if err == nil {
 		t.Fatalf("expected error, got none")
 	}

--- a/modules/module_file.go
+++ b/modules/module_file.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/file"
 )
 
@@ -36,7 +37,7 @@ func (f *FileModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *FileModule) Execute(args map[string]interface{}) (bool, error) {
+func (f *FileModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
 	var ret bool
 	var err error

--- a/modules/module_file_test.go
+++ b/modules/module_file_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/file"
 )
 
@@ -44,6 +45,8 @@ func TestCheck(t *testing.T) {
 
 func TestAbsent(t *testing.T) {
 
+	env := environment.New()
+
 	// Create a temporary file
 	tmpfile, err := ioutil.TempFile("", "example")
 	if err != nil {
@@ -64,7 +67,7 @@ func TestAbsent(t *testing.T) {
 
 	// Run the module
 	f := &FileModule{}
-	changed, err := f.Execute(args)
+	changed, err := f.Execute(env, args)
 
 	if err != nil {
 		t.Fatalf("unexpected error")
@@ -80,7 +83,7 @@ func TestAbsent(t *testing.T) {
 
 	// Run the module again to confirm "no change" when asked to remove a file
 	// that does not exist.
-	changed, err = f.Execute(args)
+	changed, err = f.Execute(env, args)
 
 	if err != nil {
 		t.Fatalf("unexpected error")

--- a/modules/module_git.go
+++ b/modules/module_git.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	mcfg "github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/file"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/config"
@@ -50,7 +51,7 @@ func (g *GitModule) verbose(msg string) {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (g *GitModule) Execute(args map[string]interface{}) (bool, error) {
+func (g *GitModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
 	// Repository location - we've already confirmed these are valid
 	// in our check function.

--- a/modules/module_link.go
+++ b/modules/module_link.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/file"
 )
 
@@ -31,7 +32,7 @@ func (f *LinkModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *LinkModule) Execute(args map[string]interface{}) (bool, error) {
+func (f *LinkModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
 	// Get the target
 	target := StringParam(args, "target")

--- a/modules/module_package.go
+++ b/modules/module_package.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/modules/system"
 )
 
@@ -74,7 +75,7 @@ func (pm *PackageModule) getPackages(args map[string]interface{}) []string {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (pm *PackageModule) Execute(args map[string]interface{}) (bool, error) {
+func (pm *PackageModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
 	// Did we make a change, by installing/removing a package?
 	changed := false

--- a/modules/module_shell.go
+++ b/modules/module_shell.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 )
 
 // ShellModule stores our state
@@ -35,7 +36,7 @@ func (f *ShellModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *ShellModule) Execute(args map[string]interface{}) (bool, error) {
+func (f *ShellModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
 	// Get the command
 	str := StringParam(args, "command")

--- a/modules/module_shell_test.go
+++ b/modules/module_shell_test.go
@@ -55,7 +55,7 @@ func TestShell(t *testing.T) {
 	// Arguments
 	args := make(map[string]interface{})
 
-	// Rn with no arguments to see an error
+	// Run with no arguments to see an error
 	changed, err := sQuiet.Execute(env, args)
 	if changed {
 		t.Fatalf("unexpected change")

--- a/modules/module_shell_test.go
+++ b/modules/module_shell_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 )
 
 func TestShellCheck(t *testing.T) {
@@ -49,11 +50,13 @@ func TestShell(t *testing.T) {
 	sQuiet := &ShellModule{cfg: &config.Config{Verbose: false}}
 	sVerbose := &ShellModule{cfg: &config.Config{Verbose: true}}
 
+	env := environment.New()
+
 	// Arguments
 	args := make(map[string]interface{})
 
 	// Rn with no arguments to see an error
-	changed, err := sQuiet.Execute(args)
+	changed, err := sQuiet.Execute(env, args)
 	if changed {
 		t.Fatalf("unexpected change")
 	}
@@ -67,7 +70,7 @@ func TestShell(t *testing.T) {
 	// Now setup a command to run - a harmless one!
 	args["command"] = "true"
 
-	changed, err = sQuiet.Execute(args)
+	changed, err = sQuiet.Execute(env, args)
 
 	if !changed {
 		t.Fatalf("Expected to see changed result")
@@ -76,7 +79,7 @@ func TestShell(t *testing.T) {
 		t.Fatalf("unexpected error:%s", err.Error())
 	}
 
-	changed, err = sVerbose.Execute(args)
+	changed, err = sVerbose.Execute(env, args)
 
 	if !changed {
 		t.Fatalf("Expected to see changed result")
@@ -87,7 +90,7 @@ func TestShell(t *testing.T) {
 
 	// Try a command with redirection
 	args["command"] = "true >/dev/null"
-	changed, err = sQuiet.Execute(args)
+	changed, err = sQuiet.Execute(env, args)
 
 	if !changed {
 		t.Fatalf("Expected to see changed result")
@@ -98,7 +101,7 @@ func TestShell(t *testing.T) {
 
 	// Now finally try a command that doesn't exist.
 	args["command"] = "/this/does/not/exist"
-	changed, err = sQuiet.Execute(args)
+	changed, err = sQuiet.Execute(env, args)
 
 	if changed {
 		t.Fatalf("Didn't expect to see changed result")

--- a/modules/module_user_unix.go
+++ b/modules/module_user_unix.go
@@ -7,10 +7,12 @@ import (
 	"os/exec"
 	"os/user"
 	"syscall"
+
+	"github.com/skx/marionette/environment"
 )
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (g *UserModule) Execute(args map[string]interface{}) (bool, error) {
+func (g *UserModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
 	// User/State - we've already confirmed these are valid
 	// in our check function.

--- a/modules/module_user_windows.go
+++ b/modules/module_user_windows.go
@@ -4,10 +4,12 @@ package modules
 
 import (
 	"fmt"
+
+	"github.com/skx/marionette/environment"
 )
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (g *UserModule) Execute(args map[string]interface{}) (bool, error) {
+func (g *UserModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
 	if g.cfg.Verbose {
 		fmt.Printf("'user' module is not implemented upon Windows\n")


### PR DESCRIPTION
This allows modules to use variables defined in the environment.

This is the basis for implementing #59.