### PR TITLE
Improve logging.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -9,6 +9,7 @@ package ast
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/skx/marionette/conditionals"
 	"github.com/skx/marionette/token"
@@ -107,7 +108,34 @@ func (r *Rule) String() string {
 		return "<nil>"
 	}
 
-	return fmt.Sprintf("Rule %s{ name:%s}", r.Type, r.Name)
+	args := ""
+	for k, v := range r.Params {
+
+		// try to format the value
+		val := ""
+
+		str, ok := v.(string)
+		if ok {
+			val = fmt.Sprintf("\"%s\"", str)
+		}
+
+		array, ok2 := v.([]string)
+		if ok2 {
+			for _, s := range array {
+				val += fmt.Sprintf(", \"%s\"", s)
+			}
+			val = strings.TrimPrefix(val, ", ")
+			val = "[" + val + "]"
+		}
+
+		// now add on the value(s)
+		args += fmt.Sprintf(", %s->%s", k, val)
+	}
+
+	// trip prefix
+	args = strings.TrimPrefix(args, ", ")
+
+	return fmt.Sprintf("Rule %s{%s}", r.Type, args)
 }
 
 // Program contains a program

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -8,12 +8,15 @@
 package ast
 
 import (
+	"fmt"
+
 	"github.com/skx/marionette/conditionals"
 	"github.com/skx/marionette/token"
 )
 
 // Node represents a node.
 type Node interface {
+	String() string
 }
 
 // Assign represents a variable assignment.
@@ -31,6 +34,23 @@ type Assign struct {
 	Value token.Token
 }
 
+// String turns an Assign object into a decent string.
+func (a *Assign) String() string {
+	if a == nil {
+		return "<nil>"
+	}
+	t := "string"
+	switch a.Value.Type {
+	case token.BACKTICK:
+		t = "backtick"
+	case token.STRING:
+		t = "string"
+	default:
+		t = "unknown"
+	}
+	return (fmt.Sprintf("Assign{Key:%s Value:%s Type:%s}", a.Key, a.Value.Literal, t))
+}
+
 // Include represents a file inclusion.
 //
 // This is produced by the parser by include statements.
@@ -46,6 +66,18 @@ type Include struct {
 
 	// ConditionRule holds a conditional-rule to match, if ConditionType is non-empty.
 	ConditionRule *conditionals.ConditionCall
+}
+
+// String turns an Include object into a useful string.
+func (i *Include) String() string {
+	if i == nil {
+		return "<nil>"
+	}
+	if i.ConditionType == "" {
+		return (fmt.Sprintf("Include{ Source:%s }", i.Source))
+	}
+	return (fmt.Sprintf("Include{ Source:%s  ConditionType:%s Condition:%s}",
+		i.Source, i.ConditionType, i.ConditionRule))
 }
 
 // Rule represents a parsed rule.
@@ -67,6 +99,15 @@ type Rule struct {
 
 	// Parameters contains the params supplied by the user.
 	Params map[string]interface{}
+}
+
+// String turns a Rule object into a useful string
+func (r *Rule) String() string {
+	if r == nil {
+		return "<nil>"
+	}
+
+	return fmt.Sprintf("Rule %s{ name:%s}", r.Type, r.Name)
 }
 
 // Program contains a program

--- a/config/config.go
+++ b/config/config.go
@@ -8,8 +8,11 @@ package config
 // made available to all of our plugins.
 type Config struct {
 
-	// Verbose is the only configuration option at the moment,
-	// and controls whether we should be quiet, or noisy, when
-	// processing our rule-files.
+	// Debug is used to let our plugins know that the marionette
+	// CLI was started with the `-debug` flag present.
+	Debug bool
+
+	// Verbose is used to let our plugins know that the marionette
+	// CLI was started with the `-verbose` flag present.
 	Verbose bool
 }

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -3,6 +3,7 @@
 package environment
 
 import (
+	"log"
 	"os"
 	"os/user"
 	"runtime"
@@ -46,6 +47,11 @@ func New() *Environment {
 	if err == nil {
 		tmp.vars["USERNAME"] = user.Username
 		tmp.vars["HOMEDIR"] = user.HomeDir
+	}
+
+	// Log our default variables
+	for key, val := range tmp.vars {
+		log.Printf("[DEBUG] Set default variable %s -> %s\n", key, val)
 	}
 
 	return tmp

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -628,11 +628,6 @@ func (e *Executor) mapper(val string) string {
 // runCommand returns the output of the specified command
 func (e *Executor) runCommand(command string) (string, error) {
 
-	// Are we running under a fuzzer?  If so disable this
-	if os.Getenv("FUZZ") == "FUZZ" {
-		return command, nil
-	}
-
 	// Build up the thing to run, using a shell so that
 	// we can handle pipes/redirection.
 	toRun := []string{"/bin/bash", "-c", command}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -519,6 +519,8 @@ func (e *Executor) executeSingleRule(rule *ast.Rule) error {
 				return err
 			}
 		}
+	} else {
+		log.Printf("[INFO] Rule resulted in no change being made.")
 	}
 
 	// All done

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.7.4 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/kevinburke/ssh_config v1.1.0 // indirect
 	github.com/moby/term v0.0.0-20200611042045-63b9a826fb74 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -390,6 +390,8 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
+github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/main.go
+++ b/main.go
@@ -86,7 +86,10 @@ func main() {
 	log.SetOutput(filter)
 
 	// Create our configuration object
-	cfg := &config.Config{Verbose: *verbose}
+	cfg := &config.Config{
+		Debug:   *debug,
+		Verbose: *verbose,
+	}
 
 	// Ensure we got at least one recipe to execute.
 	if len(flag.Args()) < 1 {

--- a/main.go
+++ b/main.go
@@ -5,8 +5,10 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 
+	"github.com/hashicorp/logutils"
 	"github.com/skx/marionette/config"
 	"github.com/skx/marionette/executor"
 	"github.com/skx/marionette/parser"
@@ -57,8 +59,31 @@ func runFile(filename string, cfg *config.Config) error {
 func main() {
 
 	// Parse our command-line flags.
-	verbose := flag.Bool("verbose", false, "Be verbose in execution")
+	debug := flag.Bool("debug", false, "Be very verbose in logging.")
+	verbose := flag.Bool("verbose", false, "Show logs when executing")
 	flag.Parse()
+
+	// By default we set the log-level to empty, but if we're
+	// running verbosely we'll show info.
+	nop := logutils.LogLevel("NOP")
+	dbg := logutils.LogLevel("DEBUG")
+	wrn := logutils.LogLevel("INFO")
+
+	lvl := nop
+	if *verbose {
+		lvl = wrn
+	}
+	if *debug {
+		lvl = dbg
+	}
+
+	// Setup the filter
+	filter := &logutils.LevelFilter{
+		Levels:   []logutils.LogLevel{"DEBUG", "INFO", "ERROR"},
+		MinLevel: lvl,
+		Writer:   os.Stderr,
+	}
+	log.SetOutput(filter)
 
 	// Create our configuration object
 	cfg := &config.Config{Verbose: *verbose}

--- a/modules/module_docker.go
+++ b/modules/module_docker.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 
 	"github.com/docker/docker/api/types"
@@ -117,7 +118,7 @@ func (dm *DockerModule) installImage(img string) error {
 	// TODO: Clean this up
 	defer out.Close()
 
-	if dm.cfg.Verbose {
+	if dm.cfg.Debug {
 		_, err := io.Copy(os.Stdout, out)
 		if err != nil {
 			return err
@@ -164,9 +165,8 @@ func (dm *DockerModule) Execute(env *environment.Environment, args map[string]in
 		// Not installed; fetch.
 		if !present || (force == "yes") {
 
-			if dm.cfg.Verbose {
-				fmt.Printf("\tPulling docker image %s\n", img)
-			}
+			// Show what we're doing
+			log.Printf("[INFO] Pulling docker image %s\n", img)
 
 			err := dm.installImage(img)
 			if err != nil {

--- a/modules/module_git.go
+++ b/modules/module_git.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -43,13 +44,6 @@ func (g *GitModule) Check(args map[string]interface{}) error {
 	return nil
 }
 
-// verbose will show the message if the verbose flag is set
-func (g *GitModule) verbose(msg string) {
-	if g.cfg.Verbose {
-		fmt.Printf("%s\n", msg)
-	}
-}
-
 // Execute is part of the module-api, and is invoked to run a rule.
 func (g *GitModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
@@ -68,7 +62,8 @@ func (g *GitModule) Execute(env *environment.Environment, args map[string]interf
 	tmp := filepath.Join(path, ".git")
 	if !file.Exists(tmp) {
 
-		g.verbose("\tRepository not present at destination; cloning")
+		// Show what we're doing.
+		log.Printf("[DEBUG] %s not present, cloning %s", tmp, repo)
 
 		// Clone since it is missing.
 		_, err := git.PlainClone(path, false, &git.CloneOptions{
@@ -144,10 +139,7 @@ func (g *GitModule) Execute(env *environment.Environment, args map[string]interf
 
 	// If the hashes differ we've updated, and thus changed
 	if ref2.Hash() != ref.Hash() {
-		g.verbose("\tRepository updated.")
 		changed = true
-	} else {
-		g.verbose("\tNo changes to local repository.\n")
 	}
 
 	return changed, err

--- a/modules/module_package.go
+++ b/modules/module_package.go
@@ -4,6 +4,7 @@ package modules
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/skx/marionette/config"
 	"github.com/skx/marionette/environment"
@@ -18,13 +19,6 @@ type PackageModule struct {
 
 	// state when using a compatibility-module
 	state string
-}
-
-// verbose will show the message if the verbose flag is set
-func (pm *PackageModule) verbose(msg string) {
-	if pm.cfg.Verbose {
-		fmt.Printf("%s\n", msg)
-	}
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -112,6 +106,8 @@ func (pm *PackageModule) Execute(env *environment.Environment, args map[string]i
 	// For each package install/uninstall
 	for _, name := range packages {
 
+		log.Printf("[DEBUG] Testing package %s", name)
+
 		// Is it installed?
 		inst, err := pkg.IsInstalled(name)
 		if err != nil {
@@ -120,9 +116,9 @@ func (pm *PackageModule) Execute(env *environment.Environment, args map[string]i
 
 		// Show the output
 		if inst {
-			pm.verbose(fmt.Sprintf("\tPackage %s is installed", name))
+			log.Printf("[DEBUG] Package installed: %s", name)
 		} else {
-			pm.verbose(fmt.Sprintf("\tPackage %s is not currently installed", name))
+			log.Printf("[DEBUG] Package not installed: %s", name)
 		}
 
 		if state == "installed" {

--- a/modules/module_shell.go
+++ b/modules/module_shell.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -45,9 +46,7 @@ func (f *ShellModule) Execute(env *environment.Environment, args map[string]inte
 	}
 
 	// Show what we're doing.
-	if f.cfg.Verbose {
-		fmt.Printf("\tExecuting: %s\n", str)
-	}
+	log.Printf("[INFO] Executing: %s", str)
 
 	// Split on space to execute
 	var bits []string
@@ -66,7 +65,7 @@ func (f *ShellModule) Execute(env *environment.Environment, args map[string]inte
 	var execErr bytes.Buffer
 
 	// Show to the console if we should
-	if f.cfg.Verbose {
+	if f.cfg.Debug {
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
 	} else {

--- a/modules/module_user.go
+++ b/modules/module_user.go
@@ -62,13 +62,6 @@ func (g *UserModule) Check(args map[string]interface{}) error {
 	return fmt.Errorf("state must be one of 'absent' or 'present'")
 }
 
-// verbose will show the message if the verbose flag is set
-func (g *UserModule) verbose(msg string) {
-	if g.cfg.Verbose {
-		fmt.Printf("%s\n", msg)
-	}
-}
-
 // init is used to dynamically register our module.
 func init() {
 	Register("user", func(cfg *mcfg.Config) ModuleAPI {

--- a/modules/module_user_unix.go
+++ b/modules/module_user_unix.go
@@ -4,6 +4,7 @@ package modules
 
 import (
 	"fmt"
+	"log"
 	"os/exec"
 	"os/user"
 	"syscall"
@@ -77,7 +78,9 @@ func (g *UserModule) createUser(args map[string]interface{}) error {
 
 	// The user-creation command
 	cmdArgs := []string{"useradd", "--shell", shell, login}
-	g.verbose(fmt.Sprintf("Running %v", cmdArgs))
+
+	// Show what we're doing
+	log.Printf("[DEBUG] Running %s", cmdArgs)
 
 	// Run it
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
@@ -104,7 +107,9 @@ func (g *UserModule) removeUser(login string) error {
 
 	// The user-removal command
 	cmdArgs := []string{"userdel", login}
-	g.verbose(fmt.Sprintf("Running %v", cmdArgs))
+
+	// Show what we're doing
+	log.Printf("[DEBUG] Running %s", cmdArgs)
 
 	// Run it
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)

--- a/modules/module_user_windows.go
+++ b/modules/module_user_windows.go
@@ -4,6 +4,7 @@ package modules
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/skx/marionette/environment"
 )
@@ -11,9 +12,7 @@ import (
 // Execute is part of the module-api, and is invoked to run a rule.
 func (g *UserModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
-	if g.cfg.Verbose {
-		fmt.Printf("'user' module is not implemented upon Windows\n")
-	}
+	log.Printf("[ERROR] the 'user' module is not implemented upon Windows")
 
-	return false, nil
+	return false, fmt.Errorf("the 'user' module is not implemented upon Windows")
 }

--- a/parser/fuzz_test.go
+++ b/parser/fuzz_test.go
@@ -25,6 +25,10 @@ func FuzzParser(f *testing.F) {
 	f.Add([]byte(`shell { command => "/usr/bin/uptime" } `))
 	f.Add([]byte(`shell { command => [ "/usr/bin/uptime", "/usr/bin/id" ] } `))
 
+	// block with conditions
+	f.Add([]byte(`shell { command => "uptime", if => equal(\"one\",\"two\"); } `))
+	f.Add([]byte(`shell { command => "uptime", unless => false(\"/bin/true\"); } `))
+
 	// Known errors are listed here.
 	//
 	// The purpose of fuzzing is to find panics, or unexpected errors.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,16 +1,19 @@
 // Package parser contains a parser for our input language.
 //
-// We consume tokens from the lexer, and attempt to process
-// them into either:
+// We consume tokens from the lexer, and return a "Program".
 //
-//  1. A series of rules.
+// The program consists of different types of things that we
+// support at runtime:
 //
-//  2. A series of variable assignments.
+//  1. A rule to process with one of our modules.
 //
-//  We support the inclusion of other files, and command
-// expansion via backticks, but we're otherwise pretty
-// minimal.
+//  2. Variable assignments.
 //
+//  3. File inclusions.
+//
+// Expansion of variables, handling of include-files, and command
+// execution for the case of variable assignments, will all happen
+// at run-time not within this parser.
 package parser
 
 import (
@@ -277,6 +280,8 @@ func (p *Parser) parseBlock(ty string) (*ast.Rule, error) {
 		r.Params[name] = value
 	}
 
+	// If there was no name setup for the rule then we
+	// generate one.
 	r.Name = p.getName(r.Params)
 	return r, nil
 }


### PR DESCRIPTION
This pull-request, when complete, will close #64 by having logging
generate more useful output.

This initial work adds a new `-debug` flag and divides some of our
output into:

* DEBUG-level stuff
  * Shown when `-debug` is used.
  * Most people won't care about this.
* INFO-level stuff
  * Shown when `-verbose` is used.
  * This gives a rough overview of what is going on.

All logging goes to STDERR, and all logging is prefixed by date/time
and shows level.

Simple stuff but when I go over the rest of the code this will help
make sure things are consistent.

TODO

* Update all the modules.
* Optionally remove the `Config` structure
  * Since `Verbose` is no longer needed.