### PR TITLE
Add magic include variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,11 @@ The following variables are available by default:
 | `${OS}`       | The operating system name (as taken from `sys.GOOS`). |
 | `${USERNAME}` | The username of user running marionette.              |
 
+There are additionally two "magic" variables available which will update based on the current file being processed.
+
+| Name              | Value                                                            |
+| `${INCLUDE_DIR}`  | The absolute directory path of the current file being processed. |
+| `${INCLUDE_FILE}` | The absolute path of the current file being processed.           |
 
 # Module Types
 

--- a/main.go
+++ b/main.go
@@ -40,6 +40,12 @@ func runFile(filename string, cfg *config.Config) error {
 	// Mark the file as having been processed.
 	ex.MarkSeen(filename)
 
+	// // Set "magic" variables for the current include file.
+	err = ex.SetMagicIncludeVars(filename)
+	if err != nil {
+		return err
+	}
+
 	// Check for broken dependencies
 	err = ex.Check()
 	if err != nil {


### PR DESCRIPTION
After the move to the AST based approach, it's now fairly trivial to add magic variables based on the current included file. This PR adds `__FILE` and `__DIR` which are set to the full include file path and the containing directory respectively.

These are analagous to the `__FILE__` and `__DIR__` magic constants in PHP (https://www.php.net/manual/en/language.constants.magic.php) and `__dirname` and `__filename` with Node.js (https://nodejs.org/dist/latest-v17.x/docs/api/globals.html#__dirname, https://nodejs.org/dist/latest-v17.x/docs/api/globals.html#__filename). There are likely other examples but these are two I'm familiar with.

This implements #49 requested by @adam12.

Opened as a draft for discussion. Things that may want consideration
- The variable naming.
- Is `__FILE` actually useful? `__DIR` is useful in an `include` context or other places where file paths are used.