### PR TITLE
72 conditional assign

### DIFF
--- a/conditionals/conditional_on_path.go
+++ b/conditionals/conditional_on_path.go
@@ -26,7 +26,7 @@ func OnPath(args []string) (bool, error) {
 	// got an error? return it
 	if err != nil {
 		log.Printf("[DEBUG] error running lookup %s", err)
-		return false, err
+		return false, nil
 	}
 
 	log.Printf("[DEBUG] lookup resulted in '%s'", path)

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,5 +12,9 @@ This directory contains some simple examples, to show how this tool can be used.
   * It also pulls three docker containers from their remote source.
   * Finally it restarts the application.
 
+* [download.recipe](download.recipe)
+  * Demonstrates how to use the conditional assignments to choose programs.
+  * Selecting either wget or curl, depending on which is available.
+
 * [overview.recipe](overview.recipe)
   * This is a well-commented example that shows numerous examples of the various modules.

--- a/examples/download.recipe
+++ b/examples/download.recipe
@@ -1,0 +1,31 @@
+#
+# This example uses either wget, or curl, to download a file
+#
+
+#
+# Going to download this URL
+#
+let url = "https://example.com/"
+
+#
+# Going to save here
+#
+let dst = "/tmp/save"
+
+#
+# Find a binary
+#
+let cmd = "curl --output ${dst} ${url}" if on_path("fcurl")
+let cmd = "wget -O ${dst} ${url}"       if on_path("wget")
+
+#
+# Fail if we didn't
+#
+fail {
+        message => "Failed to find curl or wget on the PATH",
+        if      => unset(${cmd})
+}
+
+log {
+        message => "Download command: ${cmd}"
+}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -219,18 +219,21 @@ func TestIf(t *testing.T) {
 	//
 	params := make(map[string]interface{})
 	params["name"] = "foo"
-	params["if"] = &conditionals.ConditionCall{Name: "equals",
-		Args: []string{"foo", "bar"}}
 
 	//
 	// Create our rule.
 	//
 	r1 := []ast.Node{
 		&ast.Rule{
-			Type:      "file",
-			Name:      "test",
-			Triggered: false,
-			Params:    params,
+			Type:          "file",
+			Name:          "test",
+			Triggered:     false,
+			Params:        params,
+			ConditionType: "if",
+			ConditionRule: &conditionals.ConditionCall{
+				Name: "equals",
+				Args: []string{"foo", "bar"},
+			},
 		},
 	}
 
@@ -252,30 +255,30 @@ func TestIf(t *testing.T) {
 	//
 	// Now we try to run with the wrong type for our conditional
 	//
-	params["if"] = "foo"
-
 	// change params
 	tmp := r1[0].(*ast.Rule)
-	tmp.Params = params
+	tmp.ConditionType = "foo"
 
 	ex = New(r1)
 	err = ex.Execute()
 	if err == nil {
 		t.Errorf("expected error running rules, got none")
 	}
-	if !strings.Contains(err.Error(), "xpected a conditional structure") {
+	if !strings.Contains(err.Error(), "unknown condition-type") {
 		t.Errorf("got an error, but not the right kind: %s", err.Error())
 	}
 
 	//
 	// Finally we try to run with an unknown conditional
 	//
-	params["if"] = &conditionals.ConditionCall{Name: "agrees",
-		Args: []string{"foo", "bar"}}
-
 	// change params
 	tmpt := r1[0].(*ast.Rule)
 	tmpt.Params = params
+	tmpt.ConditionType = "if"
+	tmpt.ConditionRule = &conditionals.ConditionCall{
+		Name: "agrees",
+		Args: []string{"foo", "bar"},
+	}
 
 	ex = New(r1)
 	err = ex.Execute()
@@ -297,16 +300,27 @@ func TestTriggered(t *testing.T) {
 	//
 	r1 := []ast.Node{
 		&ast.Rule{Type: "file",
-			Name:      "bob",
-			Triggered: false,
-			Params: map[string]interface{}{"require": "test",
-				"if": &conditionals.ConditionCall{Name: "equal",
-					Args: []string{"foo", "bar"}}},
+			Name:          "bob",
+			Triggered:     false,
+			ConditionType: "if",
+			ConditionRule: &conditionals.ConditionCall{
+				Name: "equal",
+				Args: []string{"foo", "bar"},
+			},
+			Params: map[string]interface{}{
+				"require": "test",
+			},
 		},
 		&ast.Rule{Type: "file",
 			Name:      "test",
 			Triggered: true,
-			Params:    map[string]interface{}{"require": 3, "target": "/tmp/foo", "ensure": "present", "content": "foo"}},
+			Params: map[string]interface{}{
+				"require": 3,
+				"target":  "/tmp/foo",
+				"ensure":  "present",
+				"content": "foo",
+			},
+		},
 	}
 
 	//
@@ -334,18 +348,23 @@ func TestUnless(t *testing.T) {
 	//
 	params := make(map[string]interface{})
 	params["name"] = "foo"
-	params["unless"] = &conditionals.ConditionCall{Name: "equals",
-		Args: []string{"bar", "bar"}}
+	params["target"] = "foo"
+	params["source_url"] = "https://example.com/"
 
 	//
 	// Create our rule.
 	//
 	r1 := []ast.Node{
 		&ast.Rule{
-			Type:      "file",
-			Name:      "test",
-			Triggered: false,
-			Params:    params,
+			Type:          "file",
+			Name:          "test",
+			Triggered:     false,
+			Params:        params,
+			ConditionType: "unless",
+			ConditionRule: &conditionals.ConditionCall{
+				Name: "equals",
+				Args: []string{"bar", "bar"},
+			},
 		},
 	}
 
@@ -367,30 +386,28 @@ func TestUnless(t *testing.T) {
 	//
 	// Now we try to run with the wrong type for our conditional
 	//
-	params["unless"] = "foo"
-
 	// change params
 	tmp := r1[0].(*ast.Rule)
-	tmp.Params = params
+	tmp.ConditionType = "foo"
 
 	ex = New(r1)
 	err = ex.Execute()
 	if err == nil {
 		t.Errorf("expected error running rules, got none")
 	}
-	if !strings.Contains(err.Error(), "xpected a conditional structure") {
+	if !strings.Contains(err.Error(), "unknown condition-type") {
 		t.Errorf("got an error, but not the right kind: %s", err.Error())
 	}
 
 	//
 	// Finally we try to run with an unknown conditional
 	//
-	params["unless"] = &conditionals.ConditionCall{Name: "agrees",
-		Args: []string{"foo", "bar"}}
-
 	// change params
 	tmpt := r1[0].(*ast.Rule)
-	tmpt.Params = params
+	tmpt.ConditionRule = &conditionals.ConditionCall{
+		Name: "agrees",
+		Args: []string{"foo", "bar"},
+	}
 
 	ex = New(r1)
 	err = ex.Execute()

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -151,6 +151,28 @@ func (p *Parser) parseLet() (*ast.Assign, error) {
 		return let, fmt.Errorf("unexpected value for variable assignment; expected string or backtick, got %v", val)
 	}
 
+	// Look at the next token and see if it is a
+	// conditional inclusion
+	if p.peekTokenIs("if") || p.peekTokenIs("unless") {
+
+		// skip the token - after saving it
+		nxt := p.peekToken.Literal
+		p.nextToken()
+
+		// Get the name/arguments of the function call
+		// we expect to come next.
+		fname, args, error := p.parseFunctionCall()
+
+		// error? then return that
+		if error != nil {
+			return let, error
+		}
+
+		// Otherwise save the condition.
+		let.ConditionType = nxt
+		let.ConditionRule = &conditionals.ConditionCall{Name: fname, Args: args}
+	}
+
 	// Add the node to our program, and continue
 	let.Key = name.Literal
 	let.Value = val
@@ -302,7 +324,8 @@ func (p *Parser) parseBlock(ty string) (*ast.Rule, error) {
 			//
 			// Save those values away in our interface map.
 			//
-			r.Params[name] = &conditionals.ConditionCall{Name: fname, Args: args}
+			r.ConditionType = name
+			r.ConditionRule = &conditionals.ConditionCall{Name: fname, Args: args}
 			continue
 		}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -152,7 +152,7 @@ func (p *Parser) parseLet() (*ast.Assign, error) {
 	}
 
 	// Look at the next token and see if it is a
-	// conditional inclusion
+	// conditional assignment.
 	if p.peekTokenIs("if") || p.peekTokenIs("unless") {
 
 		// skip the token - after saving it

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/skx/marionette/ast"
-	"github.com/skx/marionette/conditionals"
 )
 
 // TestAssignment performs basic assignment-statement testing
@@ -175,12 +174,14 @@ func TestConditional(t *testing.T) {
 	}
 
 	rule := out.Recipe[0].(*ast.Rule)
-	res, ok := rule.Params["if"].(*conditionals.ConditionCall)
-	if !ok {
+
+	// Did we get the right type of condition?
+	if rule.ConditionType != "if" {
 		t.Errorf("we didn't parse a conditional")
 	}
 
-	formatted := res.String()
+	// Does it look like the right test?
+	formatted := rule.ConditionRule.String()
 	if formatted != "equal(foo,foo)" {
 		t.Errorf("failed to stringify valid comparison")
 	}


### PR DESCRIPTION
Allow assignments to be conditional.
    
This pull-request overhauls how the conditional-keys were handledfor rule-execution:
    
* In the past we stored the conditions in the map of parameters
  * Under keys "unless" or "if".
* Now we store them in distinct places within our Rule-node
  * Just like we did for file-inclusion.
    
This means that we have two objects which support conditional execution and they are both handled the same way:
    
* Inclusions
* Rules
    
Once that was done I added the same struct-members to the assignment object, and updated the parser to populate them.  The result of that is that all three of our nodes support conditional "stuff", and it is handled in the same way.

Test cases updated to cope with the change, and a new example was added to document things.
    
This closes #72
