### PR TITLE
Exclude `user` and `group` from MacOS

### DIFF
--- a/modules/module_group_not_unix.go
+++ b/modules/module_group_not_unix.go
@@ -1,10 +1,11 @@
-//go:build windows
+//go:build darwin || windows
 
 package modules
 
 import (
 	"fmt"
 	"log"
+	"runtime"
 
 	"github.com/skx/marionette/environment"
 )
@@ -12,7 +13,9 @@ import (
 // Execute is part of the module-api, and is invoked to run a rule.
 func (g *GroupModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
-	log.Printf("[ERROR] the 'group' module is not implemented upon Windows")
+	message := "the 'group' module is not implemented on this platform"
 
-	return false, fmt.Errorf("the 'group' module is not implemented upon Windows")
+	log.Printf("[ERROR] %s: %s", message, runtime.GOOS)
+
+	return false, fmt.Errorf("%s: %s", message, runtime.GOOS)
 }

--- a/modules/module_group_unix.go
+++ b/modules/module_group_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !darwin && !windows
 
 package modules
 

--- a/modules/module_user_not_unix.go
+++ b/modules/module_user_not_unix.go
@@ -1,10 +1,11 @@
-//go:build windows
+//go:build darwin || windows
 
 package modules
 
 import (
 	"fmt"
 	"log"
+	"runtime"
 
 	"github.com/skx/marionette/environment"
 )
@@ -12,7 +13,9 @@ import (
 // Execute is part of the module-api, and is invoked to run a rule.
 func (g *UserModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
-	log.Printf("[ERROR] the 'user' module is not implemented upon Windows")
+	message := "the 'user' module is not implemented on this platform"
 
-	return false, fmt.Errorf("the 'user' module is not implemented upon Windows")
+	log.Printf("[ERROR] %s: %s", message, runtime.GOOS)
+
+	return false, fmt.Errorf("%s: %s", message, runtime.GOOS)
 }

--- a/modules/module_user_unix.go
+++ b/modules/module_user_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !darwin && !windows
 
 package modules
 


### PR DESCRIPTION
This prevents `user` and `group` from being used on MacOS.

All other rules seem to work with the exception of `docker` and `package`, understandably.

- `docker` - Fails with `Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`
- `package` - Fails with `failed to recognize system-type`