### PR TITLE
84 backticks

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -116,6 +116,14 @@ type Rule struct {
 	Triggered bool
 
 	// Parameters contains the params supplied by the user.
+	//
+	// The keys will be strings, with the values being either
+	// a single token, or an array of tokens.
+	//
+	// (We need to store the tokens here, because we need to
+	// be able to differentiate later whether we received a
+	// string or a backtick-string which should be expanded
+	// at runtime.)
 	Params map[string]interface{}
 
 	// ConditionType holds "if" or "unless" if this rule should
@@ -139,12 +147,12 @@ func (r *Rule) String() string {
 		// try to format the value
 		val := ""
 
-		str, ok := v.(string)
+		str, ok := v.(token.Token)
 		if ok {
 			val = fmt.Sprintf("\"%s\"", str)
 		}
 
-		array, ok2 := v.([]string)
+		array, ok2 := v.([]token.Token)
 		if ok2 {
 			for _, s := range array {
 				val += fmt.Sprintf(", \"%s\"", s)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/skx/marionette/ast"
 	"github.com/skx/marionette/conditionals"
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/token"
 )
 
 // TestSimpleRule tests that running a simple rule succeeds
@@ -32,8 +33,8 @@ func TestSimpleRule(t *testing.T) {
 	// Setup the parameters
 	//
 	params := make(map[string]interface{})
-	params["target"] = tmpfile.Name()
-	params["content"] = expected
+	params["target"] = token.Token{Type: token.STRING, Literal: tmpfile.Name()}
+	params["content"] = token.Token{Type: token.STRING, Literal: expected}
 
 	//
 	// Create a simple rule

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -161,7 +161,7 @@ func TestBrokenDependencies(t *testing.T) {
 	//
 	params := make(map[string]interface{})
 	// -> missing rule
-	params["require"] = "foo"
+	params["require"] = token.Token{Type: token.STRING, Literal: "foo"}
 
 	//
 	// Create a rule with a single dependency
@@ -175,7 +175,11 @@ func TestBrokenDependencies(t *testing.T) {
 
 	//
 	// Create a rule with a pair of dependencies
-	params["require"] = []string{"foo", "bar"}
+	params["require"] = []token.Token{
+		token.Token{Type: token.STRING, Literal: "foo"},
+		token.Token{Type: token.STRING, Literal: "bar"},
+	}
+
 	r2 := []ast.Node{
 		&ast.Rule{Type: "file",
 			Name:      "test",

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -354,11 +354,11 @@ func (p *Parser) getName(params map[string]interface{}) string {
 	if ok {
 
 		// OK we did.  Was it a string?
-		str, ok := n.(string)
+		str, ok := n.(token.Token)
 		if ok {
 
 			// Yes.  Use it.
-			return str
+			return str.Literal
 		}
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -416,52 +416,64 @@ func (p *Parser) parseFunctionCall() (string, []string, error) {
 
 // readValue returns the value associated with a name.
 //
-// The value is either a string, or an array of strings.
+// This is used when parsing blocks/rules, and it will return either
+// an array of tokens, or a single token.
+//
+// We need to return tokens here, rather than their literal contents,
+// so that we can later differentiate between "strings" and "backtick-strings"
+// which should be expanded at run-time.
 func (p *Parser) readValue(name string) (interface{}, error) {
 
-	var a []string
+	// The return value.
+	var result []token.Token
 
-	t := p.nextToken()
+	// Get the next value
+	tok := p.nextToken()
 
 	// error checking
-	if t.Type == token.ILLEGAL {
-		return nil, fmt.Errorf("found illegal token:%v processing block %s", t, name)
+	if tok.Type == token.ILLEGAL {
+		return nil, fmt.Errorf("found illegal token:%v processing block %s", tok, name)
 	}
-	if t.Type == token.EOF {
+	if tok.Type == token.EOF {
 		return nil, fmt.Errorf("found end of file processing block %s", name)
 	}
 
-	// string or backticks
-	if t.Type == token.STRING || t.Type == token.BACKTICK {
-		return t.Literal, nil
+	// If we got a single string or backtick we're good
+	if tok.Type == token.STRING || tok.Type == token.BACKTICK {
+		return tok, nil
 	}
 
 	// array?
-	if t.Type != token.LSQUARE {
+	if tok.Type != token.LSQUARE {
 		return nil, fmt.Errorf("not a string or an array for value in block %s", name)
 	}
 
+	// OK we've got an array of values
 	for {
-		t := p.nextToken()
+		// Get the value
+		tok = p.nextToken()
 
 		// error checking
-		if t.Type == token.ILLEGAL {
-			return nil, fmt.Errorf("found illegal token:%v processing block %s", t, name)
+		if tok.Type == token.ILLEGAL {
+			return nil, fmt.Errorf("found illegal token:%v processing block %s", tok, name)
 		}
-		if t.Type == token.EOF {
+		if tok.Type == token.EOF {
 			return nil, fmt.Errorf("found end of file, processing block %s", name)
 		}
 
-		if t.Type == token.COMMA {
+		// commas are separators, and are skipped
+		if tok.Type == token.COMMA {
 			continue
 		}
 
-		if t.Type == token.STRING {
-			a = append(a, t.Literal)
+		// If this is a string/backtick-string then append the token
+		if tok.Type == token.STRING || tok.Type == token.BACKTICK {
+			result = append(result, tok)
 		}
 
-		if t.Type == token.RSQUARE {
-			return a, nil
+		// block will be terminated by a "]"
+		if tok.Type == token.RSQUARE {
+			return result, nil
 		}
 	}
 }

--- a/token/token.go
+++ b/token/token.go
@@ -2,6 +2,8 @@
 // and which our parser understands.
 package token
 
+import "fmt"
+
 // Type is a string
 type Type string
 
@@ -28,3 +30,20 @@ const (
 	RPAREN   = ")"
 	STRING   = "STRING"
 )
+
+// String turns the token into a readable string
+func (t Token) String() string {
+
+	// string?
+	if t.Type == STRING {
+		return t.Literal
+	}
+
+	// backtick?
+	if t.Type == BACKTICK {
+		return "`" + t.Literal + "`"
+	}
+
+	// everything else is less pretty
+	return fmt.Sprintf("token{Type:%s Literal:%s}", t.Type, t.Literal)
+}


### PR DESCRIPTION
This pull-request closes #84, by restoring the ability to execute commands via the backtick operator in rule-blocks.

Sample usage:

```
frodo ~/Repos/github.com/skx/marionette $ cat backticks.recipe 
log {
        message => `uptime`,
}
frodo ~/Repos/github.com/skx/marionette $ ./marionette backticks.recipe 
2022/01/11 18:41:55 [USER]  18:41:55 up 71 days, 23:02,  1 user,  load average: 0.73, 0.62, 0.54
```

Parameter expansion is thus restored to what it used to be, before we moved to the AST-based interpreter which had file-inclusion and variable assignments executed at parse-time.