### PR TITLE
Improve usability in our parser

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -236,8 +236,14 @@ func (l *Lexer) peekChar() rune {
 
 // determinate whether the given character is legal within an identifier or not.
 func isIdentifier(ch rune) bool {
-	return !isWhitespace(ch) && ch != rune(',') && ch != rune('(') && ch != rune(')') && ch != rune('=') && !isEmpty(ch)
-
+	return !isWhitespace(ch) &&
+		ch != rune(',') &&
+		ch != rune('(') &&
+		ch != rune(')') &&
+		ch != rune('{') &&
+		ch != rune('}') &&
+		ch != rune('=') &&
+		!isEmpty(ch)
 }
 
 // is the character white space?

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -239,3 +239,22 @@ func TestInclude(t *testing.T) {
 		}
 	}
 }
+
+// #86 - Test we can parse modules without spaces
+func TestModuleSpace(t *testing.T) {
+
+	input := `shell{command=>"id"}`
+
+	p := New(input)
+	out, err := p.Parse()
+
+	// This should be error-free
+	if err != nil {
+		t.Errorf("unexpected error parsing input '%s': %s", input, err.Error())
+	}
+
+	// We should have one result
+	if len(out.Recipe) != 1 {
+		t.Errorf("unexpected number of results")
+	}
+}


### PR DESCRIPTION
This pull-request will close #86 by preventing "{" and "}" from being considered valid characters in identifers.

This has the net result that `shell{command...` will be parsed correctly, whereas previously it would have resulted in a parse failure as that would have been turned into the _identifier_ with name `shell{command` - which would then have triggered a syntax-error as the expected `{` wouldn't have been found to follow that identifier.
