### PR TITLE
Add a -version flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,8 +66,15 @@ func main() {
 
 	// Parse our command-line flags.
 	debug := flag.Bool("debug", false, "Be very verbose in logging.")
-	verbose := flag.Bool("verbose", false, "Show logs when executing")
+	verbose := flag.Bool("verbose", false, "Show logs when executing.")
+	version := flag.Bool("version", false, "Show our version number.")
 	flag.Parse()
+
+	// If we're showing the version, then do so and exit
+	if *version {
+		showVersion()
+		return
+	}
 
 	// By default we set the log-level to "USER", which will
 	// allow the user-generated messages from our log-module

--- a/version.go
+++ b/version.go
@@ -1,0 +1,16 @@
+//go:build !go1.18
+// +build !go1.18
+
+package main
+
+import (
+	"fmt"
+)
+
+var (
+	version = "unreleased"
+)
+
+func showVersion() {
+	fmt.Printf("%s\n", version)
+}

--- a/version18.go
+++ b/version18.go
@@ -1,0 +1,29 @@
+//go:build go1.18
+// +build go1.18
+
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+	"strings"
+)
+
+var (
+	version = "unreleased"
+)
+
+func showVersion() {
+	fmt.Printf("%s\n", version)
+
+	info, ok := debug.ReadBuildInfo()
+
+	if ok {
+		for _, settings := range info.Settings {
+			if strings.Contains(settings.Key, "vcs") {
+				fmt.Printf("%s: %s\n", settings.Key, settings.Value)
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
This shows the version, and exits cleanly, when -version is specified.

There are two implementations one for go 1.18+ and one for previous
releases - the newer version shows details about our repository:

      $ ./marionette -version
      unreleased
      vcs: git
      vcs.revision: 2bb0b080a0308ddcb4ae7d9fb00441bcf05df7e0
      vcs.time: 2022-02-10T04:20:12Z
      vcs.modified: true

This closes #92.