### PR TITLE
101 types

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,8 @@ docker { image => "alpine:latest" }
 The following keys are supported:
 
 * `image` - The image/images to fetch.
-* `force` - If this is set to "yes" then we fetch the image even if it appears to be available locally already.
+* `force`
+  * If this is set to `true` then we fetch the image even if it appears to be available locally already.
 
 **NOTE**: We don't support private registries, or the use of authentication.
 
@@ -600,7 +601,7 @@ Valid parameters are:
 
 * `package` is a mandatory parameter, containing the package, or list of packages.
 * `state` - Should be one of `installed` or `absent`, depending upon whether you want to install or uninstall the named package(s).
-* `update` - If this is set to `yes` then the system will be updated prior to installation.
+* `update` - If this is set to `true` then the system will be updated prior to installation.
   * In the case of a Debian system, for example, `apt-get update` will be executed.
 
 
@@ -667,10 +668,10 @@ By default commands are executed directly, unless they contain redirection-chara
 
 * `bash -c "${command}"`
 
-You may specify `shell => "true"` to force the use of a shell, despite the lack of redirection/pipe characters:
+You may specify `shell => true` to force the use of a shell, despite the lack of redirection/pipe characters:
 
 ```
-shell { shell   => "true",
+shell { shell   => true,
         command => "sed .. /etc/file.txt"
       }
 ```

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Example usage:
 log { message => "I'm ${USER} running on ${HOSTNAME}" }
 ```
 
-The only valid parameter is `message`, which must be a single string.
+The only valid parameter is `message`, which may be either a single value, or an array of values.
 
 See also [fail](#fail), which will log a message but then terminate execution.
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -55,6 +55,10 @@ func (a *Assign) String() string {
 	switch a.Value.Type {
 	case token.BACKTICK:
 		t = "backtick"
+	case token.BOOLEAN:
+		t = "boolean"
+	case token.NUMBER:
+		t = "number"
 	case token.STRING:
 		t = "string"
 	}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -97,8 +97,8 @@ func (e *Environment) ExpandVariables(input string) string {
 // ExpandTokenVariables is similar to the ExpandVariables, the
 // difference is that it uses a token as an input, rather than a string.
 //
-// This is specifically so that if a token is used of type `BACKTICK`
-// we can execute shell commands.
+// This is done so that if a token is used of type `BACKTICK` we can
+// execute the appropriate shell command(s).
 func (e *Environment) ExpandTokenVariables(tok token.Token) (string, error) {
 
 	// Expand any variables

--- a/examples/433-mhz-temperature-grapher-docker.recipe
+++ b/examples/433-mhz-temperature-grapher-docker.recipe
@@ -47,7 +47,7 @@ docker {
                      "grafana/grafana:latest",
                      "hertzg/rtl_433:latest",
                    ],
-          force => "yes",
+          force  => true,
           notify => "temperature:restart"
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -665,6 +665,12 @@ func (e *Executor) expandToken(tok token.Token) (string, error) {
 	switch tok.Type {
 	case token.STRING:
 		ret = e.env.ExpandVariables(tok.Literal)
+	case token.NUMBER:
+		// A number returns the string-value of the token
+		ret = tok.Literal
+	case token.BOOLEAN:
+		// A boolean returns the string-value of itself
+		ret = tok.Literal
 	case token.BACKTICK:
 		ret, err = e.env.ExpandTokenVariables(tok)
 		if err != nil {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -37,12 +37,12 @@ type Executor struct {
 	// their index.
 	index map[string]int
 
-	// Keep track of which rules we've executed
+	// Keep track of which rules we've executed.
 	executed map[string]bool
 
 	// included keeps track of which files we've already included.
 	//
-	// We use this to avoid issues with recursive file inclusions
+	// We use this to avoid issues with recursive file inclusions.
 	included map[string]bool
 
 	// cfg holds our configuration options.
@@ -258,6 +258,7 @@ func (e *Executor) Execute() error {
 		switch r := r.(type) {
 
 		case *ast.Assign:
+
 			log.Printf("[DEBUG] Processing assignment: %s", r)
 
 			// variable assignment
@@ -277,9 +278,10 @@ func (e *Executor) Execute() error {
 			}
 
 		case *ast.Rule:
-			// rule execution
+
 			log.Printf("[DEBUG] Processing rule: %s", r)
 
+			// rule execution
 			err := e.executeSingleRule(r)
 			if err != nil {
 				return err

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -376,7 +376,7 @@ func (e *Executor) executeInclude(inc *ast.Include) error {
 // setting up the include-file history & etc.
 func (e *Executor) executeIncludeReal(source string) error {
 
-	// Now run the inclusion
+	// Read the source we're to include
 	data, err := ioutil.ReadFile(source)
 	if err != nil {
 		return fmt.Errorf("failed to read include-source %s: %s", source, err)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -333,5 +333,5 @@ func isEmpty(ch rune) bool {
 
 // Is the given character a digit?
 func isDigit(ch rune) bool {
-	return unicode.IsDigit(ch)
+	return rune('0') <= ch && ch <= rune('9')
 }

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -284,9 +284,6 @@ func (l *Lexer) readString() (string, error) {
 			if l.ch == rune('t') {
 				l.ch = '\t'
 			}
-			if l.ch == rune('\'') {
-				l.ch = '\''
-			}
 			if l.ch == rune('"') {
 				l.ch = '"'
 			}
@@ -338,6 +335,7 @@ func isIdentifier(ch rune) bool {
 		ch != rune('{') &&
 		ch != rune('}') &&
 		ch != rune('=') &&
+		ch != rune(';') &&
 		!isEmpty(ch)
 }
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -2,6 +2,7 @@ package lexer
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/skx/marionette/token"
@@ -29,7 +30,13 @@ func TestEmpty(t *testing.T) {
 
 // TestAssign tests we can assign something.
 func TestAssign(t *testing.T) {
-	input := `let foo = "steve";`
+
+	// Setup debugging
+	old := os.Getenv("DEBUG_LEXER")
+	os.Setenv("DEBUG_LEXER", "true")
+	input := `let foo = "steve";
+let bar = true;
+let baz = false;`
 
 	tests := []struct {
 		expectedType    token.Type
@@ -39,18 +46,28 @@ func TestAssign(t *testing.T) {
 		{token.IDENT, "foo"},
 		{token.ASSIGN, "="},
 		{token.STRING, "steve"},
+		{token.IDENT, "let"},
+		{token.IDENT, "bar"},
+		{token.ASSIGN, "="},
+		{token.BOOLEAN, "true"},
+		{token.IDENT, "let"},
+		{token.IDENT, "baz"},
+		{token.ASSIGN, "="},
+		{token.BOOLEAN, "false"},
 		{token.EOF, ""},
 	}
 	l := New(input)
 	for i, tt := range tests {
 		tok := l.NextToken()
-		if tok.Type != tt.expectedType {
-			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
-		}
 		if tok.Literal != tt.expectedLiteral {
 			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
 		}
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+
+		}
 	}
+	os.Setenv("DEBUG_LEXER", old)
 }
 
 // TestEscape ensures that strings have escape-characters processed.
@@ -297,9 +314,39 @@ func Test15Assignment(t *testing.T) {
 	}
 }
 
+// TestParseNumber ensures we can catch errors in numbers
+func TestParseNumber(t *testing.T) {
+
+	// Parsing a number
+	lex := New("449691189")
+	tok := lex.NextToken()
+
+	if tok.Type != token.NUMBER {
+		t.Fatalf("parsed number as wrong type")
+	}
+	if tok.Literal != "449691189" {
+		t.Fatalf("error lexing got:%s", tok.Literal)
+	}
+
+	// Now a number that's out of range.
+	lex = New("18446744073709551620")
+	lex.decimal = true
+
+	tok = lex.NextToken()
+
+	if tok.Type != token.ILLEGAL {
+		t.Fatalf("parsed number as wrong type")
+	}
+	if !strings.Contains(tok.Literal, "out of range") {
+		t.Fatalf("got error, but wrong one: %s", tok.Literal)
+	}
+
+}
+
 // TestInteger tests that we parse integers appropriately.
 func TestInteger(t *testing.T) {
 
+	old := os.Getenv("DECIMAL_NUMBERS")
 	os.Setenv("DECIMAL_NUMBERS", "true")
 
 	type TestCase struct {
@@ -322,4 +369,6 @@ func TestInteger(t *testing.T) {
 			t.Fatalf("error lexing %s - expected:%s got:%s", tst.input, tst.output, tok.Literal)
 		}
 	}
+
+	os.Setenv("DECIMAL_NUMBERS", old)
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -1,6 +1,7 @@
 package lexer
 
 import (
+	"os"
 	"testing"
 
 	"github.com/skx/marionette/token"
@@ -298,6 +299,7 @@ func Test15Assignment(t *testing.T) {
 
 // TestInteger tests that we parse integers appropriately.
 func TestInteger(t *testing.T) {
+	os.Setenv("DECIMAL_NUMBERS", "true")
 
 	type TestCase struct {
 		input  string

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -295,3 +295,28 @@ func Test15Assignment(t *testing.T) {
 		i++
 	}
 }
+
+// TestInteger tests that we parse integers appropriately.
+func TestInteger(t *testing.T) {
+
+	type TestCase struct {
+		input  string
+		output string
+	}
+
+	tests := []TestCase{
+		{input: "3", output: "3"},
+		{input: "0xff", output: "255"},
+		{input: "0b11111111", output: "255"},
+	}
+
+	for _, tst := range tests {
+
+		lex := New(tst.input)
+		tok := lex.NextToken()
+
+		if tok.Literal != tst.output {
+			t.Fatalf("error lexing %s - expected:%s got:%s", tst.input, tst.output, tok.Literal)
+		}
+	}
+}

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -299,6 +299,7 @@ func Test15Assignment(t *testing.T) {
 
 // TestInteger tests that we parse integers appropriately.
 func TestInteger(t *testing.T) {
+
 	os.Setenv("DECIMAL_NUMBERS", "true")
 
 	type TestCase struct {

--- a/main.go
+++ b/main.go
@@ -65,6 +65,9 @@ func runFile(filename string, cfg *config.Config) error {
 func main() {
 
 	// Parse our command-line flags.
+	dL := flag.Bool("dl", false, "Debug the lexer?")
+	dP := flag.Bool("dp", false, "Debug the parser?")
+
 	debug := flag.Bool("debug", false, "Be very verbose in logging.")
 	verbose := flag.Bool("verbose", false, "Show logs when executing.")
 	version := flag.Bool("version", false, "Show our version number.")
@@ -76,6 +79,20 @@ func main() {
 		return
 	}
 
+	// The lexer and parser can optionally output information
+	// to the console.
+	//
+	// These decide whether to do this via environmental variables
+	// if we've been given the appropriate flags then we set those
+	// variables here.
+	if *dL {
+		os.Setenv("DEBUG_LEXER", "true")
+	}
+	if *dP {
+		os.Setenv("DEBUG_PARSER", "true")
+	}
+
+	//
 	// By default we set the log-level to "USER", which will
 	// allow the user-generated messages from our log-module
 	// to be visible.

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func main() {
 	dL := flag.Bool("dl", false, "Debug the lexer?")
 	dP := flag.Bool("dp", false, "Debug the parser?")
 
+	decimal := flag.Bool("decimal", true, "Convert numbers to decimal, automatically.")
 	debug := flag.Bool("debug", false, "Be very verbose in logging.")
 	verbose := flag.Bool("verbose", false, "Show logs when executing.")
 	version := flag.Bool("version", false, "Show our version number.")
@@ -90,6 +91,9 @@ func main() {
 	}
 	if *dP {
 		os.Setenv("DEBUG_PARSER", "true")
+	}
+	if *decimal {
+		os.Setenv("DECIMAL_NUMBERS", "true")
 	}
 
 	//

--- a/modules/module_docker.go
+++ b/modules/module_docker.go
@@ -163,7 +163,7 @@ func (dm *DockerModule) Execute(env *environment.Environment, args map[string]in
 		}
 
 		// Not installed; fetch.
-		if !present || (force == "yes") {
+		if !present || (force == "yes") || (force == "true") {
 
 			// Show what we're doing
 			log.Printf("[INFO] Pulling docker image %s\n", img)

--- a/modules/module_log.go
+++ b/modules/module_log.go
@@ -30,8 +30,13 @@ func (f *LogModule) Check(args map[string]interface{}) error {
 // Execute is part of the module-api, and is invoked to run a rule.
 func (f *LogModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
-	// Get the message
-	arg := args["message"]
+	// Get the message/messages to log.
+	arg, ok := args["message"]
+
+	// Ensure that we've got something
+	if !ok {
+		return false, fmt.Errorf("missing 'message' parameter")
+	}
 
 	// string?
 	str, ok := arg.(string)

--- a/modules/module_log.go
+++ b/modules/module_log.go
@@ -18,16 +18,10 @@ type LogModule struct {
 // Check is part of the module-api, and checks arguments.
 func (f *LogModule) Check(args map[string]interface{}) error {
 
-	// Ensure we have a message to log.
+	// Ensure we have a message, or messages, to log.
 	_, ok := args["message"]
 	if !ok {
 		return fmt.Errorf("missing 'message' parameter")
-	}
-
-	// Ensure the message is a string
-	msg := StringParam(args, "message")
-	if msg == "" {
-		return fmt.Errorf("failed to convert 'message' to string")
 	}
 
 	return nil
@@ -37,17 +31,24 @@ func (f *LogModule) Check(args map[string]interface{}) error {
 func (f *LogModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
 
 	// Get the message
-	str := StringParam(args, "message")
-	if str == "" {
-		return false, fmt.Errorf("missing 'message' parameter")
+	arg := args["message"]
+
+	// string?
+	str, ok := arg.(string)
+	if ok {
+		log.Print("[USER] " + str)
+		return true, nil
 	}
 
-	// Show the message
-	log.Print("[USER] " + str)
+	// otherwise we assume it is an array of commands
+	strs := arg.([]string)
 
-	// Log always results in a change
+	// process each argument
+	for _, str = range strs {
+		log.Print("[USER] " + str)
+	}
+
 	return true, nil
-
 }
 
 // init is used to dynamically register our module.

--- a/modules/module_log_test.go
+++ b/modules/module_log_test.go
@@ -36,16 +36,6 @@ func TestLogArguments(t *testing.T) {
 		t.Fatalf("got error - but wrong one : %s", err)
 	}
 
-	// Wrong kind of argument
-	args["message"] = 3
-	err = l.Check(args)
-	if err == nil {
-		t.Fatalf("expected error due to missing message-parameter")
-	}
-	if !strings.Contains(err.Error(), "failed to convert") {
-		t.Fatalf("got error - but wrong one : %s", err)
-	}
-
 	// Valid argument
 	args["message"] = "Hello, world"
 	err = l.Check(args)

--- a/modules/module_package.go
+++ b/modules/module_package.go
@@ -86,7 +86,7 @@ func (pm *PackageModule) Execute(env *environment.Environment, args map[string]i
 	// we'll accept it for the module globally as there is no
 	// harm in it.
 	p := StringParam(args, "update")
-	if p == "yes" {
+	if p == "yes" || p == "true" {
 		err := pkg.Update()
 		if err != nil {
 			return false, err

--- a/parser/fuzz_test.go
+++ b/parser/fuzz_test.go
@@ -16,13 +16,18 @@ func FuzzParser(f *testing.F) {
 	// invalid entries
 	f.Add([]byte("let"))
 	f.Add([]byte("3="))
+	f.Add([]byte("let false=\"steve\" "))
 
 	// assignments
 	f.Add([]byte("let foo=\"bar\""))
+	f.Add([]byte("let foo=3"))
+	f.Add([]byte("let foo=true"))
+	f.Add([]byte("let foo=false"))
 	f.Add([]byte("let id=`/usr/bin/id -u`"))
 
 	// blocks
-	f.Add([]byte(`shell { command => "/usr/bin/uptime" } `))
+	f.Add([]byte(`shell { command => "/usr/bin/uptime", shell => true } `))
+	f.Add([]byte(`shell { command => "/usr/bin/uptime", shell => "true" } `))
 	f.Add([]byte(`shell { command => [ "/usr/bin/uptime", "/usr/bin/id" ] } `))
 
 	// block with conditions
@@ -37,6 +42,8 @@ func FuzzParser(f *testing.F) {
 	// report those known-bad things.
 	known := []string{
 		"expected",
+		"expected identifier name after conditional",
+		"assignment can only be made to identifiers",
 		"illegal token",
 		"end of file",
 		"unterminated assignment",

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -174,7 +174,10 @@ func (p *Parser) parseLet() (*ast.Assign, error) {
 	}
 
 	// assignment only handles strings/command-output
-	if val.Type != token.STRING && val.Type != token.BACKTICK {
+	if val.Type != token.BOOLEAN &&
+		val.Type != token.BACKTICK &&
+		val.Type != token.NUMBER &&
+		val.Type != token.STRING {
 		return let, fmt.Errorf("unexpected value for variable assignment; expected string or backtick, got %v", val)
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -173,7 +173,7 @@ func (p *Parser) parseLet() (*ast.Assign, error) {
 		return let, fmt.Errorf("unterminated assignment")
 	}
 
-	// assignment only handles strings/command-ouptut
+	// assignment only handles strings/command-output
 	if val.Type != token.STRING && val.Type != token.BACKTICK {
 		return let, fmt.Errorf("unexpected value for variable assignment; expected string or backtick, got %v", val)
 	}
@@ -465,7 +465,7 @@ func (p *Parser) readValue(name string) (interface{}, error) {
 		return nil, fmt.Errorf("found end of file processing block %s", name)
 	}
 
-	// If we got a single string or backtick we're good
+	// If we got a simple type we're good
 	if tok.Type == token.BOOLEAN || tok.Type == token.NUMBER || tok.Type == token.STRING || tok.Type == token.BACKTICK {
 		return tok, nil
 	}
@@ -493,8 +493,11 @@ func (p *Parser) readValue(name string) (interface{}, error) {
 			continue
 		}
 
-		// If this is a string/backtick-string then append the token
-		if tok.Type == token.STRING || tok.Type == token.BACKTICK {
+		// If this is a simple type then append the token
+		if tok.Type == token.STRING ||
+			tok.Type == token.NUMBER ||
+			tok.Type == token.BOOLEAN ||
+			tok.Type == token.BACKTICK {
 			result = append(result, tok)
 		}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -439,7 +439,7 @@ func (p *Parser) readValue(name string) (interface{}, error) {
 	}
 
 	// If we got a single string or backtick we're good
-	if tok.Type == token.STRING || tok.Type == token.BACKTICK {
+	if tok.Type == token.BOOLEAN || tok.Type == token.NUMBER || tok.Type == token.STRING || tok.Type == token.BACKTICK {
 		return tok, nil
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -5,6 +5,7 @@
 package parser
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -20,7 +21,6 @@ func TestAssignment(t *testing.T) {
 		"let foo",
 		"let foo=",
 		"let foo=bar",
-		"let foo=1",
 		"let a=\"b\" unless",
 		"let a=\"b\" unless false",
 		"let a=\"b\" unless false(",
@@ -260,6 +260,30 @@ func TestModuleSpace(t *testing.T) {
 
 	// We should have one result
 	if len(out.Recipe) != 1 {
+		t.Errorf("unexpected number of results")
+	}
+}
+
+// Test that we can output debug-strings
+func TestDebug(t *testing.T) {
+
+	// One example of each rule-type
+	input := `
+include "foo.txt"
+let a = 3
+shell{command=>"id"}
+`
+	os.Setenv("DEBUG_PARSER", "true")
+	p := New(input)
+	out, err := p.Parse()
+
+	// This should be error-free
+	if err != nil {
+		t.Errorf("unexpected error parsing input '%s': %s", input, err.Error())
+	}
+
+	// We should have three results
+	if len(out.Recipe) != 3 {
 		t.Errorf("unexpected number of results")
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -224,8 +224,8 @@ func TestInclude(t *testing.T) {
 	// Now test valid includes
 	valid := []string{
 		"include \"test.inc\"",
-		"include \"test.inc\" unless false(/bin/ls)",
-		"include \"test.inc\" if true(/bin/ls)",
+		"include \"test.inc\" unless failure(/bin/ls)",
+		"include \"test.inc\" if success(/bin/ls)",
 	}
 
 	// Ensure each one succeeds

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -30,6 +30,9 @@ func TestAssignment(t *testing.T) {
 		"let a=\"3\" if     true(",
 		"let a=\"3\" if     true(/bin/ls",
 		"let a=\"3\" if     true(/bin/ls,",
+		"let 3=\"3\"",
+		"let false=\"3\"",
+		"let true=\"3\"",
 	}
 
 	// Ensure each one fails
@@ -48,6 +51,8 @@ func TestAssignment(t *testing.T) {
 		"let x = `/bin/true`",
 		"let x = `/bin/true` if equal(\"a\",\"a\")",
 		"let a = \"boo\"",
+		"let _false_ = \"ok\"",
+		"let _true_like = \"ok\"",
 	}
 
 	// Ensure each one succeeds

--- a/token/token.go
+++ b/token/token.go
@@ -4,10 +4,10 @@ package token
 
 import "fmt"
 
-// Type is a string
+// Type is a string.
 type Type string
 
-// Token struct represent the lexer token
+// Token struct represent the token which is returned from the lexer.
 type Token struct {
 	Type    Type
 	Literal string
@@ -15,20 +15,25 @@ type Token struct {
 
 // pre-defined TokenTypes
 const (
+	// Things
 	ASSIGN   = "="
 	BACKTICK = "`"
 	COMMA    = ","
 	EOF      = "EOF"
-	IDENT    = "IDENT"
-	ILLEGAL  = "ILLEGAL"
 	LASSIGN  = "=>"
 	LBRACE   = "{"
+	LPAREN   = "("
 	LSQUARE  = "["
 	RBRACE   = "}"
-	RSQUARE  = "]"
-	LPAREN   = "("
 	RPAREN   = ")"
-	STRING   = "STRING"
+	RSQUARE  = "]"
+
+	// types
+	BOOLEAN = "BOOLEAN"
+	IDENT   = "IDENT"
+	ILLEGAL = "ILLEGAL"
+	NUMBER  = "NUMBER"
+	STRING  = "STRING"
 )
 
 // String turns the token into a readable string


### PR DESCRIPTION
This pull-request defines two new token-types:

* Booleans
  * Which are the literal strings `true` and `false`.
* Numbers
  *  We default to base-10, but we support binary numbers such as `0b0101011` and hexadecimal values, such as `0xfffe`

These values are returned by the lexer, but at parse-time they're essentially treated as strings.  So there's no specific type information being used.

The net result is that this is valid:

```
log { message => 0xffef }
log { message => true }
```
This gets handled like so:

```
2022/02/14 11:52:24 [DEBUG] Processing rule: Rule log{message->"token{Type:NUMBER Literal:0xffef}"}
2022/02/14 11:52:24 [INFO] Running log-module rule: c5dfdc07-3e46-45a6-b90e-a2dd8ed4535b
2022/02/14 11:52:24 [USER] 0xffef
2022/02/14 11:52:24 [INFO] Rule resulted in a change being made.


2022/02/14 11:52:24 [DEBUG] Processing rule: Rule log{message->"token{Type:BOOLEAN Literal:true}"}
2022/02/14 11:52:24 [INFO] Running log-module rule: a946b4d8-0539-40a8-b2d0-0cdad4def95f
2022/02/14 11:52:24 [USER] true
2022/02/14 11:52:24 [INFO] Rule resulted in a change being made.

```

We need to update the test-cases to account for these new types, run the fuzz-testing some more, and sanity-check all the modules that use these types.

It might be worth adding some dumping-options to dump the lexed-tokens, or parse-tree, to make sure there aren't surprises in the future too.

Once this is complete, this will close #101.
