### PR TITLE
Report when a parent-directory doesn't exist

### DIFF
--- a/modules/module_file.go
+++ b/modules/module_file.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 	"text/template"
 
 	"github.com/skx/marionette/config"
@@ -50,6 +51,12 @@ func (f *FileModule) Execute(env *environment.Environment, args map[string]inter
 
 	// Get the target (i.e. file/directory we're operating upon.)
 	target := StringParam(args, "target")
+
+	// Get the directory-name
+	dir := filepath.Dir(target)
+	if !file.Exists(dir) {
+		return false, fmt.Errorf("error: directory %s does not exist, when processing %s", dir, target)
+	}
 
 	// We assume we're creating the file, but we might be removing it.
 	state := StringParam(args, "state")


### PR DESCRIPTION
In the past the following content would give a confusing error
message:

```
file {
    target => "/does/not/exist/1.txt",
    content => "I am created",
}
```

The error would be:

```
$ ./marionette file.in
Error:error running file-module rule '3dd3f261-53f4-4a3d-b89c-d415e976d851' open /does/not/exist/1.txt: no such file or directory
```

After this pull-request you'd instead see something more useful:

```
$ ./marionette file.in
Error:error running file-module rule '3dd3f261-53f4-4a3d-b89c-d415e976d851' open /does/not/exist/1.txt: no such file or directory
```

This closes #91.