### PR TITLE
Update the module API

### DIFF
--- a/ast/builtin_test.go
+++ b/ast/builtin_test.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -66,16 +67,23 @@ func TestFunctionArgs(t *testing.T) {
 		valid := m[name]
 
 		if valid == 1 {
-			_, err = fun(nil, one)
+			t.Run(name, func(t *testing.T) {
+				_, err = fun(nil, one)
+			})
+			if err != nil {
+				t.Fatalf("unexpected error with 1 arg")
+			}
 		} else if valid == 2 {
-			_, err = fun(nil, two)
+			t.Run(name, func(t *testing.T) {
+				_, err = fun(nil, two)
+			})
+			if err != nil {
+				t.Fatalf("unexpected error with 2 args")
+			}
 		} else {
 			t.Fatalf("unhandled test-case for function '%s'", name)
 		}
 
-		if err != nil {
-			t.Fatalf("unexpected error invoking %s with %d args", name, valid)
-		}
 	}
 
 }
@@ -399,35 +407,38 @@ func TestFunctions(t *testing.T) {
 
 	for _, test := range tests {
 
-		// Find the function
-		fun, ok := FUNCTIONS[test.Name]
-		if !ok {
-			t.Fatalf("failed to find test")
-		}
+		t.Run(fmt.Sprintf("%s(%s) -> %s", test.Name, test.Input, test.Output), func(t *testing.T) {
 
-		// Call the function
-		ret, err := fun(nil, test.Input)
+			// Find the function
+			fun, ok := FUNCTIONS[test.Name]
+			if !ok {
+				t.Fatalf("failed to find test")
+			}
 
-		// Got an error making the call
-		if err != nil {
+			// Call the function
+			ret, err := fun(nil, test.Input)
 
-			// Should we have done?
-			if test.Error != "" {
+			// Got an error making the call
+			if err != nil {
 
-				if !strings.Contains(err.Error(), test.Error) {
-					t.Fatalf("expected error (%s), but got different one (%s)", test.Error, err.Error())
+				// Should we have done?
+				if test.Error != "" {
+
+					if !strings.Contains(err.Error(), test.Error) {
+						t.Fatalf("expected error (%s), but got different one (%s)", test.Error, err.Error())
+					}
+				} else {
+					t.Fatalf("unexpected error calling %s(%v) %s", test.Name, test.Input, err)
 				}
 			} else {
-				t.Fatalf("unexpected error calling %s(%v) %s", test.Name, test.Input, err)
-			}
-		} else {
-			// Compare the results
-			a := test.Output.String()
-			b := ret.String()
+				// Compare the results
+				a := test.Output.String()
+				b := ret.String()
 
-			if a != b {
-				t.Fatalf("error running test %s(%v) - %s != %s", test.Name, test.Input, a, b)
+				if a != b {
+					t.Fatalf("error running test %s(%v) - %s != %s", test.Name, test.Input, a, b)
+				}
 			}
-		}
+		})
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,8 @@
 // and made available to all our plugins.
 package config
 
+import "fmt"
+
 // Config holds the state which is set by the main driver, and is
 // made available to all of our plugins.
 type Config struct {
@@ -15,4 +17,12 @@ type Config struct {
 	// Verbose is used to let our plugins know that the marionette
 	// CLI was started with the `-verbose` flag present.
 	Verbose bool
+}
+
+// String converts this object to a string, only used for the test-case.
+func (c *Config) String() string {
+	if c == nil {
+		return "Config{nil}"
+	}
+	return fmt.Sprintf("Config{Debug:%t Verbose:%t}", c.Debug, c.Verbose)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,60 @@
+// Package config holds global options.
+//
+// Options are intended to be set via the command-line flags,
+// and made available to all our plugins.
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfig(t *testing.T) {
+
+	// Create an object
+	c := &Config{Debug: false, Verbose: false}
+
+	// Verify the options are sane
+	if c.Debug != false {
+		t.Fatalf("structure test failed")
+	}
+	if c.Verbose != false {
+		t.Fatalf("structure test failed")
+	}
+
+	// Convert to string
+	out := c.String()
+	if !strings.Contains(out, "Debug:false") {
+		t.Fatalf("string output has wrong content")
+	}
+	if !strings.Contains(out, "Verbose:false") {
+		t.Fatalf("string output has wrong content")
+	}
+
+	// Change settings
+	c.Debug = true
+	out = c.String()
+	if !strings.Contains(out, "Debug:true") {
+		t.Fatalf("string output has wrong content")
+	}
+	if !strings.Contains(out, "Verbose:false") {
+		t.Fatalf("string output has wrong content")
+	}
+
+	// Change settings
+	c.Verbose = true
+	out = c.String()
+	if !strings.Contains(out, "Debug:true") {
+		t.Fatalf("string output has wrong content")
+	}
+	if !strings.Contains(out, "Verbose:true") {
+		t.Fatalf("string output has wrong content")
+	}
+
+	// Nil-test
+	c = nil
+	out = c.String()
+	if out != "Config{nil}" {
+		t.Fatalf("string output has wrong content for nil object")
+	}
+}

--- a/environment/environment_test.go
+++ b/environment/environment_test.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"os"
 	"runtime"
 	"testing"
 )
@@ -10,6 +11,7 @@ func TestExpected(t *testing.T) {
 
 	x := New()
 
+	// Get the arch
 	a, aOK := x.Get("ARCH")
 	if !aOK {
 		t.Fatalf("Failed to get ${ARCH}")
@@ -18,6 +20,7 @@ func TestExpected(t *testing.T) {
 		t.Fatalf("${ARCH} had wrong value != %s", runtime.GOARCH)
 	}
 
+	// Get the OS
 	o, oOK := x.Get("OS")
 	if !oOK {
 		t.Fatalf("Failed to get ${OS}")
@@ -25,6 +28,24 @@ func TestExpected(t *testing.T) {
 	if o != runtime.GOOS {
 		t.Fatalf("${OS} had wrong value != %s", runtime.GOOS)
 	}
+
+	// Test getting environmental variables
+	testVar := "steve"
+	os.Setenv("TEST_ME", testVar)
+	out := x.ExpandVariables("${TEST_ME}")
+	if out != "steve" {
+		t.Fatalf("${TEST_ME} had wrong value != %s", testVar)
+	}
+
+	// Chagne the variable in the map, which will
+	// take precedence to the env
+	updated := "OK, Computer"
+	x.vars["TEST_ME"] = updated
+	out = x.ExpandVariables("${TEST_ME}")
+	if out != updated {
+		t.Fatalf("${TEST_ME} had wrong value %s != %s", out, updated)
+	}
+
 }
 
 // TestSet ensures a value will remain

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -551,7 +551,7 @@ func (e *Executor) executeSingleRule(rule *ast.Rule, force bool) error {
 	var err error
 
 	// Create the instance of the module
-	helper := modules.Lookup(rule.Type, e.cfg)
+	helper := modules.Lookup(rule.Type, e.cfg, e.env)
 	if helper == nil {
 		return fmt.Errorf("unknown module type %s, from rule %v", rule.Type, rule)
 	}
@@ -650,7 +650,7 @@ func (e *Executor) runInternalModule(helper modules.ModuleAPI, rule *ast.Rule) (
 	}
 
 	// Execute the module.
-	changed, err := helper.Execute(e.env, params)
+	changed, err := helper.Execute(params)
 	if err != nil {
 		return false, fmt.Errorf("error running %s-module rule '%s' %s",
 			rule.Type, rule.Name, err.Error())

--- a/modules/api.go
+++ b/modules/api.go
@@ -4,8 +4,12 @@
 package modules
 
 import (
+	"github.com/skx/marionette/config"
 	"github.com/skx/marionette/environment"
 )
+
+// ModuleConstructor is the signature of a constructor-function.
+type ModuleConstructor func(cfg *config.Config, env *environment.Environment) ModuleAPI
 
 // ModuleAPI is the interface which all of our modules must implement.
 //
@@ -27,7 +31,7 @@ type ModuleAPI interface {
 	//
 	// The return value is true if the module made a change
 	// and false otherwise.
-	Execute(*environment.Environment, map[string]interface{}) (bool, error)
+	Execute(map[string]interface{}) (bool, error)
 }
 
 // ModuleOutput is an optional interface that may be implemented by any of
@@ -35,7 +39,6 @@ type ModuleAPI interface {
 //
 // If this interface is implemented it is possible for modules to set
 // values in the environment after they've been executed.
-//
 type ModuleOutput interface {
 
 	// GetOutputs will return a set of key-value pairs.

--- a/modules/api_glue.go
+++ b/modules/api_glue.go
@@ -4,19 +4,17 @@ import (
 	"sync"
 
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 )
 
 // This is a map of known modules.
 var handlers = struct {
-	m map[string]TestCtor
+	m map[string]ModuleConstructor
 	sync.RWMutex
-}{m: make(map[string]TestCtor)}
-
-// TestCtor is the signature of a constructor-function.
-type TestCtor func(cfg *config.Config) ModuleAPI
+}{m: make(map[string]ModuleConstructor)}
 
 // Register records a new module.
-func Register(id string, newfunc TestCtor) {
+func Register(id string, newfunc ModuleConstructor) {
 	handlers.Lock()
 	handlers.m[id] = newfunc
 	handlers.Unlock()
@@ -31,12 +29,12 @@ func RegisterAlias(alias string, impl string) {
 
 // Lookup is the factory-method which looks up and returns
 // an object of the given type - if possible.
-func Lookup(id string, cfg *config.Config) (a ModuleAPI) {
+func Lookup(id string, cfg *config.Config, env *environment.Environment) (a ModuleAPI) {
 	handlers.RLock()
 	ctor, ok := handlers.m[id]
 	handlers.RUnlock()
 	if ok {
-		a = ctor(cfg)
+		a = ctor(cfg, env)
 	}
 	return
 }

--- a/modules/api_glue_test.go
+++ b/modules/api_glue_test.go
@@ -5,19 +5,21 @@ import (
 	"testing"
 
 	"github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 )
 
 func TestModules(t *testing.T) {
 
-	// Create our configuration object
+	// Create our configuration & environment objects
 	cfg := &config.Config{Verbose: false}
+	env := &environment.Environment{}
 
 	// Get all modules
 	modules := Modules()
 
 	for _, module := range modules {
 
-		mod := Lookup(module, cfg)
+		mod := Lookup(module, cfg, env)
 		if mod == nil {
 			t.Fatalf("failed to load module")
 		}
@@ -36,8 +38,8 @@ func TestModules(t *testing.T) {
 		t.Fatalf("unexpected number of modules: %d", len(Modules()))
 	}
 
-	a := fmt.Sprintf("%v", Lookup("cmd", cfg))
-	b := fmt.Sprintf("%v", Lookup("shell", cfg))
+	a := fmt.Sprintf("%v", Lookup("cmd", cfg, env))
+	b := fmt.Sprintf("%v", Lookup("shell", cfg, env))
 	if a != b {
 		t.Fatalf("alias didn't seem to work?: %s != %s", a, b)
 	}

--- a/modules/module_directory.go
+++ b/modules/module_directory.go
@@ -14,6 +14,9 @@ import (
 type DirectoryModule struct {
 	// cfg contains our configuration object.
 	cfg *config.Config
+
+	// env holds our environment
+	env *environment.Environment
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -31,7 +34,7 @@ func (f *DirectoryModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *DirectoryModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (f *DirectoryModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// Ensure we have one or more targets to process
 	_, ok := args["target"]
@@ -166,7 +169,8 @@ func (f *DirectoryModule) executeSingle(target string, args map[string]interface
 
 // init is used to dynamically register our module.
 func init() {
-	Register("directory", func(cfg *config.Config) ModuleAPI {
-		return &DirectoryModule{cfg: cfg}
+	Register("directory", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &DirectoryModule{cfg: cfg,
+			env: env}
 	})
 }

--- a/modules/module_directory_test.go
+++ b/modules/module_directory_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/file"
 )
 
@@ -53,8 +52,7 @@ func TestDirectoryMultiple(t *testing.T) {
 	}
 
 	d := &DirectoryModule{}
-	env := environment.New()
-	changed, err := d.Execute(env, args)
+	changed, err := d.Execute(args)
 
 	if err != nil {
 		t.Fatalf("error making multiple directories:%s", err)
@@ -65,7 +63,7 @@ func TestDirectoryMultiple(t *testing.T) {
 
 	// Second time around the directories should exist,
 	// so we see no change
-	changed, err = d.Execute(env, args)
+	changed, err = d.Execute(args)
 
 	if err != nil {
 		t.Fatalf("error making multiple directories:%s", err)
@@ -84,7 +82,7 @@ func TestDirectoryMultiple(t *testing.T) {
 
 	// Now remove them
 	args["state"] = "absent"
-	changed, err = d.Execute(env, args)
+	changed, err = d.Execute(args)
 
 	if err != nil {
 		t.Fatalf("error removing multiple directories:%s", err)
@@ -101,7 +99,7 @@ func TestDirectoryMultiple(t *testing.T) {
 	}
 
 	// remove them again - should be no change
-	changed, err = d.Execute(env, args)
+	changed, err = d.Execute(args)
 	if err != nil {
 		t.Fatalf("error removing multiple directories:%s", err)
 	}
@@ -132,8 +130,7 @@ func TestDirectoryMkdirP(t *testing.T) {
 	}
 
 	d := &DirectoryModule{}
-	env := environment.New()
-	changed, err := d.Execute(env, args)
+	changed, err := d.Execute(args)
 
 	if err != nil {
 		t.Fatalf("error making nested-directories:%s", err)
@@ -149,7 +146,7 @@ func TestDirectoryMkdirP(t *testing.T) {
 
 	// Now remove them
 	args["state"] = "absent"
-	changed, err = d.Execute(env, args)
+	changed, err = d.Execute(args)
 
 	if err != nil {
 		t.Fatalf("error removing nested-directories:%s", err)
@@ -163,7 +160,7 @@ func TestDirectoryMkdirP(t *testing.T) {
 	}
 
 	// remove them again - should be no change
-	changed, err = d.Execute(env, args)
+	changed, err = d.Execute(args)
 	if err != nil {
 		t.Fatalf("error removing multiple directories:%s", err)
 	}

--- a/modules/module_docker.go
+++ b/modules/module_docker.go
@@ -21,6 +21,9 @@ type DockerModule struct {
 	// cfg contains our configuration object.
 	cfg *config.Config
 
+	// env holds our environment
+	env *environment.Environment
+
 	// Cached list of image-tags we've got available on the local host.
 	Tags []string
 }
@@ -130,7 +133,7 @@ func (dm *DockerModule) installImage(img string) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (dm *DockerModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (dm *DockerModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// We might have multiple images to fetch
 	var images []string
@@ -182,7 +185,10 @@ func (dm *DockerModule) Execute(env *environment.Environment, args map[string]in
 
 // init is used to dynamically register our module.
 func init() {
-	Register("docker", func(cfg *config.Config) ModuleAPI {
-		return &DockerModule{cfg: cfg}
+	Register("docker", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &DockerModule{
+			cfg: cfg,
+			env: env,
+		}
 	})
 }

--- a/modules/module_edit.go
+++ b/modules/module_edit.go
@@ -17,6 +17,9 @@ type EditModule struct {
 
 	// cfg contains our configuration object.
 	cfg *config.Config
+
+	// env holds our environment
+	env *environment.Environment
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -37,7 +40,7 @@ func (e *EditModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (e *EditModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (e *EditModule) Execute(args map[string]interface{}) (bool, error) {
 
 	var ret bool
 
@@ -277,7 +280,10 @@ func (e *EditModule) SearchReplace(path string, search string, replace string) (
 
 // init is used to dynamically register our module.
 func init() {
-	Register("edit", func(cfg *config.Config) ModuleAPI {
-		return &EditModule{cfg: cfg}
+	Register("edit", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &EditModule{
+			cfg: cfg,
+			env: env,
+		}
 	})
 }

--- a/modules/module_edit_test.go
+++ b/modules/module_edit_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/file"
 )
 
@@ -45,8 +44,6 @@ func TestEditCheck(t *testing.T) {
 
 func TestEditAppend(t *testing.T) {
 
-	env := environment.New()
-
 	// create a temporary file
 	tmpfile, err := ioutil.TempFile("", "marionette-")
 	if err != nil {
@@ -63,7 +60,7 @@ func TestEditAppend(t *testing.T) {
 	args["target"] = tmpfile.Name()
 	args["append_if_missing"] = "Steve Kemp"
 
-	changed, err := e.Execute(env, args)
+	changed, err := e.Execute(args)
 	if err != nil {
 		t.Fatalf("error changing file")
 	}
@@ -85,7 +82,7 @@ func TestEditAppend(t *testing.T) {
 	}
 
 	// Call again
-	changed, err = e.Execute(env, args)
+	changed, err = e.Execute(args)
 	if err != nil {
 		t.Fatalf("error changing file")
 	}
@@ -106,7 +103,7 @@ func TestEditAppend(t *testing.T) {
 
 	// Finally append "Test"
 	args["append_if_missing"] = "Test"
-	changed, err = e.Execute(env, args)
+	changed, err = e.Execute(args)
 	if err != nil {
 		t.Fatalf("error changing file")
 	}
@@ -128,8 +125,6 @@ func TestEditAppend(t *testing.T) {
 
 func TestEditRemove(t *testing.T) {
 
-	env := environment.New()
-
 	// create a temporary file
 	tmpfile, err := ioutil.TempFile("", "marionette-")
 	if err != nil {
@@ -150,7 +145,7 @@ func TestEditRemove(t *testing.T) {
 	args["remove_lines"] = "^#"
 
 	// Make the change
-	changed, err := e.Execute(env, args)
+	changed, err := e.Execute(args)
 	if err != nil {
 		t.Fatalf("unexpected error")
 	}
@@ -159,7 +154,7 @@ func TestEditRemove(t *testing.T) {
 	}
 
 	// Second time nothing should happen
-	changed, err = e.Execute(env, args)
+	changed, err = e.Execute(args)
 	if err != nil {
 		t.Fatalf("unexpected error")
 	}
@@ -178,14 +173,14 @@ func TestEditRemove(t *testing.T) {
 
 	// Now test that an invalid regexp is taken
 	args["remove_lines"] = "*"
-	_, err = e.Execute(env, args)
+	_, err = e.Execute(args)
 	if err == nil {
 		t.Fatalf("expected error, got none")
 	}
 
 	// Remove the temporary file, and confirm we get something similar
 	os.Remove(tmpfile.Name())
-	_, err = e.Execute(env, args)
+	_, err = e.Execute(args)
 	if err != nil {
 		t.Fatalf("didn't expect error, got one")
 	}

--- a/modules/module_fail.go
+++ b/modules/module_fail.go
@@ -13,6 +13,9 @@ type FailModule struct {
 
 	// cfg contains our configuration object.
 	cfg *config.Config
+
+	// env holds our environment
+	env *environment.Environment
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -34,7 +37,7 @@ func (f *FailModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *FailModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (f *FailModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// Get the message
 	str := StringParam(args, "message")
@@ -52,7 +55,10 @@ func (f *FailModule) Execute(env *environment.Environment, args map[string]inter
 
 // init is used to dynamically register our module.
 func init() {
-	Register("fail", func(cfg *config.Config) ModuleAPI {
-		return &FailModule{cfg: cfg}
+	Register("fail", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &FailModule{
+			cfg: cfg,
+			env: env,
+		}
 	})
 }

--- a/modules/module_fail_test.go
+++ b/modules/module_fail_test.go
@@ -3,8 +3,6 @@ package modules
 import (
 	"strings"
 	"testing"
-
-	"github.com/skx/marionette/environment"
 )
 
 func TestFailCheck(t *testing.T) {
@@ -44,12 +42,10 @@ func TestFail(t *testing.T) {
 
 	f := &FailModule{}
 
-	env := environment.New()
-
 	// Setup params
 	args := make(map[string]interface{})
 
-	changed, err := f.Execute(env, args)
+	changed, err := f.Execute(args)
 	if err == nil {
 		t.Fatalf("expected error, got none")
 	}
@@ -63,7 +59,7 @@ func TestFail(t *testing.T) {
 	// Setup a message
 	args["message"] = "I have no cake"
 
-	changed, err = f.Execute(env, args)
+	changed, err = f.Execute(args)
 	if err == nil {
 		t.Fatalf("expected error, got none")
 	}

--- a/modules/module_file.go
+++ b/modules/module_file.go
@@ -42,9 +42,7 @@ func (f *FileModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *FileModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
-
-	f.env = env
+func (f *FileModule) Execute(args map[string]interface{}) (bool, error) {
 
 	var ret bool
 	var err error
@@ -278,7 +276,10 @@ func (f *FileModule) CreateFile(dst string, content string) (bool, error) {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("file", func(cfg *config.Config) ModuleAPI {
-		return &FileModule{cfg: cfg}
+	Register("file", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &FileModule{
+			cfg: cfg,
+			env: env,
+		}
 	})
 }

--- a/modules/module_file_test.go
+++ b/modules/module_file_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/skx/marionette/environment"
 	"github.com/skx/marionette/file"
 )
 
@@ -45,8 +44,6 @@ func TestCheck(t *testing.T) {
 
 func TestAbsent(t *testing.T) {
 
-	env := environment.New()
-
 	// Create a temporary file
 	tmpfile, err := ioutil.TempFile("", "marionette-")
 	if err != nil {
@@ -67,7 +64,7 @@ func TestAbsent(t *testing.T) {
 
 	// Run the module
 	f := &FileModule{}
-	changed, err := f.Execute(env, args)
+	changed, err := f.Execute(args)
 
 	if err != nil {
 		t.Fatalf("unexpected error")
@@ -83,7 +80,7 @@ func TestAbsent(t *testing.T) {
 
 	// Run the module again to confirm "no change" when asked to remove a file
 	// that does not exist.
-	changed, err = f.Execute(env, args)
+	changed, err = f.Execute(args)
 
 	if err != nil {
 		t.Fatalf("unexpected error")

--- a/modules/module_git.go
+++ b/modules/module_git.go
@@ -19,6 +19,9 @@ type GitModule struct {
 
 	// cfg contains our configuration object.
 	cfg *mcfg.Config
+
+	// env holds our environment
+	env *environment.Environment
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -45,7 +48,7 @@ func (g *GitModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (g *GitModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (g *GitModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// Repository location - we've already confirmed these are valid
 	// in our check function.
@@ -151,7 +154,10 @@ func (g *GitModule) Execute(env *environment.Environment, args map[string]interf
 
 // init is used to dynamically register our module.
 func init() {
-	Register("git", func(cfg *mcfg.Config) ModuleAPI {
-		return &GitModule{cfg: cfg}
+	Register("git", func(cfg *mcfg.Config, env *environment.Environment) ModuleAPI {
+		return &GitModule{
+			cfg: cfg,
+			env: env,
+		}
 	})
 }

--- a/modules/module_group.go
+++ b/modules/module_group.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 
 	mcfg "github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 )
 
 // GroupModule stores our state
@@ -16,6 +17,9 @@ type GroupModule struct {
 
 	// cfg contains our configuration object.
 	cfg *mcfg.Config
+
+	// env holds our environment
+	env *environment.Environment
 
 	// Regular expression for testing if parameters are safe
 	// and won't cause shell injection issues.
@@ -64,9 +68,10 @@ func (g *GroupModule) Check(args map[string]interface{}) error {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("group", func(cfg *mcfg.Config) ModuleAPI {
+	Register("group", func(cfg *mcfg.Config, env *environment.Environment) ModuleAPI {
 		return &GroupModule{
 			cfg: cfg,
+			env: env,
 			reg: regexp.MustCompile(`^[-_/a-zA-Z0-9]+$`),
 		}
 	})

--- a/modules/module_group_not_unix.go
+++ b/modules/module_group_not_unix.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"log"
 	"runtime"
-
-	"github.com/skx/marionette/environment"
 )
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (g *GroupModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (g *GroupModule) Execute(args map[string]interface{}) (bool, error) {
 
 	message := "the 'group' module is not implemented on this platform"
 

--- a/modules/module_group_unix.go
+++ b/modules/module_group_unix.go
@@ -8,12 +8,10 @@ import (
 	"os/exec"
 	"os/user"
 	"syscall"
-
-	"github.com/skx/marionette/environment"
 )
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (g *GroupModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (g *GroupModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// Group/State - we've already confirmed these are valid
 	// in our check function.

--- a/modules/module_http.go
+++ b/modules/module_http.go
@@ -18,6 +18,9 @@ type HTTPModule struct {
 	// cfg contains our configuration object.
 	cfg *config.Config
 
+	// env holds our environment
+	env *environment.Environment
+
 	// Save the status-code, after our request was completed.
 	statusCode int
 
@@ -47,7 +50,7 @@ func (f *HTTPModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *HTTPModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (f *HTTPModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// Get the url.
 	url := StringParam(args, "url")
@@ -139,7 +142,10 @@ func (f *HTTPModule) GetOutputs() map[string]string {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("http", func(cfg *config.Config) ModuleAPI {
-		return &HTTPModule{cfg: cfg}
+	Register("http", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &HTTPModule{
+			cfg: cfg,
+			env: env,
+		}
 	})
 }

--- a/modules/module_link.go
+++ b/modules/module_link.go
@@ -14,6 +14,9 @@ type LinkModule struct {
 
 	// cfg contains our configuration object.
 	cfg *config.Config
+
+	// env holds our environment
+	env *environment.Environment
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -32,7 +35,7 @@ func (f *LinkModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *LinkModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (f *LinkModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// Get the target
 	target := StringParam(args, "target")
@@ -99,7 +102,10 @@ func (f *LinkModule) Execute(env *environment.Environment, args map[string]inter
 
 // init is used to dynamically register our module.
 func init() {
-	Register("link", func(cfg *config.Config) ModuleAPI {
-		return &LinkModule{cfg: cfg}
+	Register("link", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &LinkModule{
+			cfg: cfg,
+			env: env,
+		}
 	})
 }

--- a/modules/module_log.go
+++ b/modules/module_log.go
@@ -13,6 +13,9 @@ type LogModule struct {
 
 	// cfg contains our configuration object.
 	cfg *config.Config
+
+	// env holds our environment
+	env *environment.Environment
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -28,7 +31,7 @@ func (f *LogModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *LogModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (f *LogModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// Get the message/messages to log.
 	arg, ok := args["message"]
@@ -58,7 +61,10 @@ func (f *LogModule) Execute(env *environment.Environment, args map[string]interf
 
 // init is used to dynamically register our module.
 func init() {
-	Register("log", func(cfg *config.Config) ModuleAPI {
-		return &LogModule{cfg: cfg}
+	Register("log", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &LogModule{
+			cfg: cfg,
+			env: env,
+		}
 	})
 }

--- a/modules/module_log_test.go
+++ b/modules/module_log_test.go
@@ -5,14 +5,10 @@ import (
 	"log"
 	"strings"
 	"testing"
-
-	"github.com/skx/marionette/environment"
 )
 
 // Test the argument validation works
 func TestLogArguments(t *testing.T) {
-
-	e := environment.New()
 
 	// Save our log writer
 	before := log.Writer()
@@ -47,7 +43,7 @@ func TestLogArguments(t *testing.T) {
 	// Try to execute - missing argument
 	//
 	c := false
-	c, err = l.Execute(e, empty)
+	c, err = l.Execute(empty)
 	if err == nil {
 		t.Fatalf("expected an error with no message.")
 	}
@@ -58,7 +54,7 @@ func TestLogArguments(t *testing.T) {
 	//
 	// Try to execute - valid argument
 	//
-	c, err = l.Execute(e, args)
+	c, err = l.Execute(args)
 	if err != nil {
 		t.Fatalf("unexpected error executing")
 	}

--- a/modules/module_package.go
+++ b/modules/module_package.go
@@ -18,6 +18,9 @@ type PackageModule struct {
 	// cfg contains our configuration object.
 	cfg *config.Config
 
+	// env holds our environment
+	env *environment.Environment
+
 	// state when using a compatibility-module
 	state string
 }
@@ -70,7 +73,7 @@ func (pm *PackageModule) getPackages(args map[string]interface{}) []string {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (pm *PackageModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (pm *PackageModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// Did we make a change, by installing/removing a package?
 	changed := false
@@ -195,15 +198,26 @@ func (pm *PackageModule) Execute(env *environment.Environment, args map[string]i
 
 // init is used to dynamically register our module.
 func init() {
-	Register("package", func(cfg *config.Config) ModuleAPI {
-		return &PackageModule{cfg: cfg}
+	Register("package", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &PackageModule{
+			cfg: cfg,
+			env: env,
+		}
 	})
 
 	// compatibility with previous releases.
-	Register("apt", func(cfg *config.Config) ModuleAPI {
-		return &PackageModule{cfg: cfg, state: "installed"}
+	Register("apt", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &PackageModule{
+			cfg:   cfg,
+			env:   env,
+			state: "installed",
+		}
 	})
-	Register("dpkg", func(cfg *config.Config) ModuleAPI {
-		return &PackageModule{cfg: cfg, state: "absent"}
+	Register("dpkg", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &PackageModule{
+			cfg:   cfg,
+			env:   env,
+			state: "absent",
+		}
 	})
 }

--- a/modules/module_shell.go
+++ b/modules/module_shell.go
@@ -17,6 +17,9 @@ type ShellModule struct {
 	// cfg contains our configuration object.
 	cfg *config.Config
 
+	// env holds our environment
+	env *environment.Environment
+
 	// Saved copy of STDOUT.
 	stdout []byte
 
@@ -37,7 +40,7 @@ func (f *ShellModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *ShellModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (f *ShellModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// Ensure we have one or more commands to run.
 	_, ok := args["command"]
@@ -175,7 +178,10 @@ func (f *ShellModule) GetOutputs() map[string]string {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("shell", func(cfg *config.Config) ModuleAPI {
-		return &ShellModule{cfg: cfg}
+	Register("shell", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &ShellModule{
+			cfg: cfg,
+			env: env,
+		}
 	})
 }

--- a/modules/module_shell_test.go
+++ b/modules/module_shell_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/skx/marionette/config"
-	"github.com/skx/marionette/environment"
 )
 
 func TestShellCheck(t *testing.T) {
@@ -40,13 +39,11 @@ func TestShell(t *testing.T) {
 	sQuiet := &ShellModule{cfg: &config.Config{Verbose: false}}
 	sVerbose := &ShellModule{cfg: &config.Config{Verbose: true}}
 
-	env := environment.New()
-
 	// Arguments
 	args := make(map[string]interface{})
 
 	// Run with no arguments to see an error
-	changed, err := sQuiet.Execute(env, args)
+	changed, err := sQuiet.Execute(args)
 	if changed {
 		t.Fatalf("unexpected change")
 	}
@@ -60,7 +57,7 @@ func TestShell(t *testing.T) {
 	// Now setup a command to run - a harmless one!
 	args["command"] = "true"
 
-	changed, err = sQuiet.Execute(env, args)
+	changed, err = sQuiet.Execute(args)
 
 	if !changed {
 		t.Fatalf("Expected to see changed result")
@@ -69,7 +66,7 @@ func TestShell(t *testing.T) {
 		t.Fatalf("unexpected error:%s", err.Error())
 	}
 
-	changed, err = sVerbose.Execute(env, args)
+	changed, err = sVerbose.Execute(args)
 
 	if !changed {
 		t.Fatalf("Expected to see changed result")
@@ -80,7 +77,7 @@ func TestShell(t *testing.T) {
 
 	// Try a command with redirection
 	args["command"] = "true >/dev/null"
-	changed, err = sQuiet.Execute(env, args)
+	changed, err = sQuiet.Execute(args)
 
 	if !changed {
 		t.Fatalf("Expected to see changed result")
@@ -91,7 +88,7 @@ func TestShell(t *testing.T) {
 
 	// Now finally try a command that doesn't exist.
 	args["command"] = "/this/does/not/exist"
-	changed, err = sQuiet.Execute(env, args)
+	changed, err = sQuiet.Execute(args)
 
 	if err == nil {
 		t.Fatalf("wanted error running missing command, got none")

--- a/modules/module_sql.go
+++ b/modules/module_sql.go
@@ -21,6 +21,9 @@ type SQLModule struct {
 
 	// cfg contains our configuration object.
 	cfg *config.Config
+
+	// env holds our environment
+	env *environment.Environment
 }
 
 // Check is part of the module-api, and checks arguments.
@@ -69,7 +72,7 @@ func (f *SQLModule) Check(args map[string]interface{}) error {
 }
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (f *SQLModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (f *SQLModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// Get our DSN + Driver
 	dsn := StringParam(args, "dsn")
@@ -140,7 +143,10 @@ func (f *SQLModule) Execute(env *environment.Environment, args map[string]interf
 
 // init is used to dynamically register our module.
 func init() {
-	Register("sql", func(cfg *config.Config) ModuleAPI {
-		return &SQLModule{cfg: cfg}
+	Register("sql", func(cfg *config.Config, env *environment.Environment) ModuleAPI {
+		return &SQLModule{
+			cfg: cfg,
+			env: env,
+		}
 	})
 }

--- a/modules/module_user.go
+++ b/modules/module_user.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 
 	mcfg "github.com/skx/marionette/config"
+	"github.com/skx/marionette/environment"
 )
 
 // UserModule stores our state
@@ -16,6 +17,9 @@ type UserModule struct {
 
 	// cfg contains our configuration object.
 	cfg *mcfg.Config
+
+	// env holds our environment
+	env *environment.Environment
 
 	// Regular expression for testing if parameters are safe
 	// and won't cause shell injection issues.
@@ -64,9 +68,10 @@ func (g *UserModule) Check(args map[string]interface{}) error {
 
 // init is used to dynamically register our module.
 func init() {
-	Register("user", func(cfg *mcfg.Config) ModuleAPI {
+	Register("user", func(cfg *mcfg.Config, env *environment.Environment) ModuleAPI {
 		return &UserModule{
 			cfg: cfg,
+			env: env,
 			reg: regexp.MustCompile(`^[-_/a-zA-Z0-9]+$`),
 		}
 	})

--- a/modules/module_user_not_unix.go
+++ b/modules/module_user_not_unix.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"log"
 	"runtime"
-
-	"github.com/skx/marionette/environment"
 )
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (g *UserModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (g *UserModule) Execute(args map[string]interface{}) (bool, error) {
 
 	message := "the 'user' module is not implemented on this platform"
 

--- a/modules/module_user_unix.go
+++ b/modules/module_user_unix.go
@@ -8,12 +8,10 @@ import (
 	"os/exec"
 	"os/user"
 	"syscall"
-
-	"github.com/skx/marionette/environment"
 )
 
 // Execute is part of the module-api, and is invoked to run a rule.
-func (g *UserModule) Execute(env *environment.Environment, args map[string]interface{}) (bool, error) {
+func (g *UserModule) Execute(args map[string]interface{}) (bool, error) {
 
 	// User/State - we've already confirmed these are valid
 	// in our check function.

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -38,12 +38,16 @@ func TestAssignment(t *testing.T) {
 	// Ensure each one fails
 	for _, test := range broken {
 
-		p := New(test)
-		_, err := p.Parse()
+		// Create a sub-test for this input
+		t.Run(test, func(t *testing.T) {
 
-		if err == nil {
-			t.Errorf("expected error parsing broken assign '%s' - got none", test)
-		}
+			p := New(test)
+			_, err := p.Parse()
+
+			if err == nil {
+				t.Errorf("expected error parsing broken assign '%s' - got none", test)
+			}
+		})
 	}
 
 	// Now test valid assignments
@@ -58,12 +62,15 @@ func TestAssignment(t *testing.T) {
 	// Ensure each one succeeds
 	for _, test := range valid {
 
-		p := New(test)
-		_, err := p.Parse()
+		// Create a sub-test for this input
+		t.Run(test, func(t *testing.T) {
+			p := New(test)
+			_, err := p.Parse()
 
-		if err != nil {
-			t.Errorf("unexpected error parsing assignment '%s': %s", test, err)
-		}
+			if err != nil {
+				t.Errorf("unexpected error parsing assignment '%s': %s", test, err)
+			}
+		})
 	}
 }
 
@@ -92,12 +99,15 @@ func TestBlock(t *testing.T) {
 
 	for _, test := range broken {
 
-		p := New(test)
-		_, err := p.Parse()
+		// Create a sub-test for this input
+		t.Run(test, func(t *testing.T) {
+			p := New(test)
+			_, err := p.Parse()
 
-		if err == nil {
-			t.Errorf("expected error parsing broken block '%s' - got none", test)
-		}
+			if err == nil {
+				t.Errorf("expected error parsing broken block '%s' - got none", test)
+			}
+		})
 	}
 
 	// valid tests
@@ -108,16 +118,20 @@ func TestBlock(t *testing.T) {
 
 	for _, test := range valid {
 
-		p := New(test)
-		rules, err := p.Parse()
+		// Create a sub-test for this input
+		t.Run(test, func(t *testing.T) {
 
-		if err != nil {
-			t.Errorf("unexpected error parsing '%s' %s", test, err.Error())
-		}
+			p := New(test)
+			rules, err := p.Parse()
 
-		if len(rules.Recipe) != 1 {
-			t.Errorf("expected a single rule")
-		}
+			if err != nil {
+				t.Errorf("unexpected error parsing '%s' %s", test, err.Error())
+			}
+
+			if len(rules.Recipe) != 1 {
+				t.Errorf("expected a single rule")
+			}
+		})
 	}
 }
 
@@ -154,16 +168,20 @@ func TestConditionalErrors(t *testing.T) {
 
 	for _, test := range broken {
 
-		p := New(test.Input)
-		_, err := p.Parse()
+		// Create a sub-test for this input
+		t.Run(test.Input, func(t *testing.T) {
 
-		if err == nil {
-			t.Errorf("expected error parsing broken input '%s' - got none", test.Input)
-		} else {
-			if !strings.Contains(err.Error(), test.Error) {
-				t.Errorf("error '%s' did not match '%s' when hadnling %s", err.Error(), test.Error, test.Input)
+			p := New(test.Input)
+			_, err := p.Parse()
+
+			if err == nil {
+				t.Errorf("expected error parsing broken input '%s' - got none", test.Input)
+			} else {
+				if !strings.Contains(err.Error(), test.Error) {
+					t.Errorf("error '%s' did not match '%s' when hadnling %s", err.Error(), test.Error, test.Input)
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -218,12 +236,15 @@ func TestInclude(t *testing.T) {
 	// Ensure each one fails
 	for _, test := range broken {
 
-		p := New(test)
-		_, err := p.Parse()
+		// Create a sub-test for this input
+		t.Run(test, func(t *testing.T) {
+			p := New(test)
+			_, err := p.Parse()
 
-		if err == nil {
-			t.Errorf("expected error parsing broken include '%s' - got none", test)
-		}
+			if err == nil {
+				t.Errorf("expected error parsing broken include '%s' - got none", test)
+			}
+		})
 	}
 
 	// Now test valid includes
@@ -236,12 +257,15 @@ func TestInclude(t *testing.T) {
 	// Ensure each one succeeds
 	for _, test := range valid {
 
-		p := New(test)
-		_, err := p.Parse()
+		// Create a sub-test for this input
+		t.Run(test, func(t *testing.T) {
+			p := New(test)
+			_, err := p.Parse()
 
-		if err != nil {
-			t.Errorf("unexpected error parsing include '%s': %s", test, err)
-		}
+			if err != nil {
+				t.Errorf("unexpected error parsing include '%s': %s", test, err)
+			}
+		})
 	}
 }
 

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -1,0 +1,24 @@
+package token
+
+import "testing"
+
+func TestTokenString(t *testing.T) {
+	// string
+	s := &Token{Type: STRING, Literal: "Moi"}
+	if s.String() != "Moi" {
+		t.Fatalf("Unexpected string-version of token.STRING")
+	}
+
+	// backtick
+	b := &Token{Type: BACKTICK, Literal: "/bin/ls"}
+	if b.String() != "`/bin/ls`" {
+		t.Fatalf("Unexpected string-version of token.BACKTICK")
+	}
+
+	// misc
+	m := &Token{Type: LSQUARE, Literal: "["}
+	if m.String() != "token{Type:[ Literal:[}" {
+		t.Fatalf("Unexpected string-version of token.LSQUARE")
+	}
+
+}


### PR DESCRIPTION
This pull-request will update the module API such that we no longer provide the `environment.Environment` object to the `Execute` function.

It was always a little weird that we passed it to `Execute` but not `Check`.  For consistency I think removing it from the place it is used, and instead passing it into the constructor where it can be used by either method is more clear.

This will close #112, once complete.