### PR TITLE
More generalized array support

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -30,7 +30,7 @@ type Assign struct {
 	Key string
 
 	// Value is the value which will be set.
-	Value Node
+	Value Object
 
 	// ConditionType holds "if" or "unless" if this assignment
 	// action is to be carried out conditionally.

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -62,7 +62,7 @@ type Include struct {
 	Node
 
 	// Source holds the location to include.
-	Source string
+	Source Object
 
 	// ConditionType holds "if" or "unless" if this inclusion is to
 	// be executed conditionally.

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -38,7 +38,7 @@ type Assign struct {
 
 	// Function holds a function to call, if this is a conditional
 	// action.
-	Function *Funcall
+	Function Funcall
 }
 
 // String turns an Assign object into a decent string.
@@ -70,7 +70,7 @@ type Include struct {
 
 	// Function holds a function to call, if this is a conditional
 	// action.
-	Function *Funcall
+	Function Funcall
 }
 
 // String turns an Include object into a useful string.
@@ -115,7 +115,7 @@ type Rule struct {
 
 	// Function holds a function to call, if this is a conditional
 	// action.
-	Function *Funcall
+	Function Funcall
 }
 
 // String turns a Rule object into a useful string

--- a/ast/object.go
+++ b/ast/object.go
@@ -41,12 +41,12 @@ type Backtick struct {
 }
 
 // String returns our object as a string.
-func (b *Backtick) String() string {
+func (b Backtick) String() string {
 	return fmt.Sprintf("Backtick{Command:%s}", b.Value)
 }
 
 // Evaluate returns the value of the Backtick object.
-func (b *Backtick) Evaluate(env *environment.Environment) (string, error) {
+func (b Backtick) Evaluate(env *environment.Environment) (string, error) {
 	ret, err := env.ExpandBacktick(b.Value)
 	return ret, err
 }
@@ -63,7 +63,7 @@ type Array struct {
 }
 
 // String returns our object as a string.
-func (a *Array) String() string {
+func (a Array) String() string {
 	tmp := []string{}
 	for _, arg := range a.Values {
 		tmp = append(tmp, arg.String())
@@ -76,7 +76,7 @@ func (a *Array) String() string {
 //
 // The evaluation here consists of the joined output of evaluating all
 // the children we contain.
-func (a *Array) Evaluate(env *environment.Environment) (string, error) {
+func (a Array) Evaluate(env *environment.Environment) (string, error) {
 	tmp := ""
 	for _, obj := range a.Values {
 		if len(tmp) > 0 {
@@ -102,7 +102,7 @@ type Boolean struct {
 }
 
 // String returns our object as a string.
-func (b *Boolean) String() string {
+func (b Boolean) String() string {
 	if b.Value {
 		return ("Boolean{true}")
 	}
@@ -110,7 +110,7 @@ func (b *Boolean) String() string {
 }
 
 // Evaluate returns the value of the Boolean object.
-func (b *Boolean) Evaluate(env *environment.Environment) (string, error) {
+func (b Boolean) Evaluate(env *environment.Environment) (string, error) {
 	if b.Value {
 		return "true", nil
 	}
@@ -130,7 +130,7 @@ type Funcall struct {
 }
 
 // Evaluate returns the value of the function call.
-func (f *Funcall) Evaluate(env *environment.Environment) (string, error) {
+func (f Funcall) Evaluate(env *environment.Environment) (string, error) {
 
 	// Lookup the function
 	fn, ok := FUNCTIONS[f.Name]
@@ -170,7 +170,7 @@ func (f *Funcall) Evaluate(env *environment.Environment) (string, error) {
 }
 
 // String returns our object as a string.
-func (f *Funcall) String() string {
+func (f Funcall) String() string {
 	args := ""
 	for _, a := range f.Args {
 		if len(args) > 0 {
@@ -193,12 +193,12 @@ type Number struct {
 }
 
 // String returns our object as a string.
-func (n *Number) String() string {
+func (n Number) String() string {
 	return fmt.Sprintf("Number{%d}", n.Value)
 }
 
 // Evaluate returns the value of the Number object.
-func (n *Number) Evaluate(env *environment.Environment) (string, error) {
+func (n Number) Evaluate(env *environment.Environment) (string, error) {
 	return fmt.Sprintf("%d", n.Value), nil
 }
 
@@ -212,14 +212,14 @@ type String struct {
 }
 
 // String returns our object as a string.
-func (s *String) String() string {
+func (s String) String() string {
 	return fmt.Sprintf("String{%s}", s.Value)
 }
 
 // Evaluate returns the value of the String object.
 //
 // This means expanding the variables contained within the string.
-func (s *String) Evaluate(env *environment.Environment) (string, error) {
+func (s String) Evaluate(env *environment.Environment) (string, error) {
 	return env.ExpandVariables(s.Value), nil
 
 }

--- a/ast/object.go
+++ b/ast/object.go
@@ -51,6 +51,47 @@ func (b *Backtick) Evaluate(env *environment.Environment) (string, error) {
 	return ret, err
 }
 
+// Array is a holder which can contain an arbitrary number of any of our primitive types.
+//
+// NOTE: Arrays cannot be nested, due to our parser-limitations.
+type Array struct {
+	// Object is our parent object.
+	Object
+
+	// Values hold the literal values we contain.
+	Values []Object
+}
+
+// String returns our object as a string.
+func (a *Array) String() string {
+	tmp := []string{}
+	for _, arg := range a.Values {
+		tmp = append(tmp, arg.String())
+	}
+
+	return fmt.Sprintf("Array{%s}", strings.Join(tmp, ","))
+}
+
+// Evaluate returns the value of the array object.
+//
+// The evaluation here consists of the joined output of evaluating all
+// the children we contain.
+func (a *Array) Evaluate(env *environment.Environment) (string, error) {
+	tmp := ""
+	for _, obj := range a.Values {
+		if len(tmp) > 0 {
+			tmp += ","
+		}
+
+		out, err := obj.Evaluate(env)
+		if err != nil {
+			return "", err
+		}
+		tmp += out
+	}
+	return tmp, nil
+}
+
 // Boolean represents a true/false value
 type Boolean struct {
 	// Object is our parent object.

--- a/ast/object_test.go
+++ b/ast/object_test.go
@@ -20,6 +20,21 @@ func TestBrokenBacktick(t *testing.T) {
 	}
 }
 
+// TestArrays handles basic array testing
+func TestArrays(t *testing.T) {
+
+	// Array
+	a := &Array{Values: []Object{
+		&Number{Value: 12},
+		&Number{Value: 34},
+	}}
+
+	_, err := a.Evaluate(nil)
+	if err != nil {
+		t.Fatalf("unexpected error evaluating an array")
+	}
+}
+
 // TestSimpleFunction tests some simple functions.
 func TestSimpleFunction(t *testing.T) {
 
@@ -73,6 +88,18 @@ func TestSimpleFunction(t *testing.T) {
 }
 
 func TestStringification(t *testing.T) {
+
+	// Array
+	a := &Array{Values: []Object{
+		&Number{Value: 12},
+		&Number{Value: 34},
+	}}
+	if !strings.Contains(a.String(), "Array") {
+		t.Fatalf("stringified object is bogus")
+	}
+	if !strings.Contains(a.String(), "Number{12},Number{34}") {
+		t.Fatalf("stringified object is bogus")
+	}
 
 	// Backtick
 	b := &Backtick{Value: "/usr/bin/id"}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -319,14 +319,8 @@ func (e *Executor) executeAssign(assign *ast.Assign) error {
 	// The key
 	key := assign.Key
 
-	// Ensure the value implements our Literal interface
-	ex, ok := assign.Value.(ast.Object)
-	if !ok {
-		return fmt.Errorf("value %v does not implement Literal interface", assign.Value)
-	}
-
 	// Execute the literal object (be it a number, string, backtick or bool)
-	val, err := ex.Evaluate(e.env)
+	val, err := assign.Value.Evaluate(e.env)
 	if err != nil {
 		return err
 	}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -34,8 +34,8 @@ func TestSimpleRule(t *testing.T) {
 	// Setup the parameters
 	//
 	params := make(map[string]interface{})
-	params["target"] = &ast.String{Value: tmpfile.Name()}
-	params["content"] = &ast.String{Value: expected}
+	params["target"] = ast.String{Value: tmpfile.Name()}
+	params["content"] = ast.String{Value: expected}
 
 	//
 	// Create a simple rule
@@ -162,7 +162,7 @@ func TestBrokenDependencies(t *testing.T) {
 	//
 	params := make(map[string]interface{})
 	// -> missing rule
-	params["require"] = &ast.String{Value: "foo"}
+	params["require"] = ast.String{Value: "foo"}
 
 	//
 	// Create a rule with a single dependency
@@ -176,9 +176,11 @@ func TestBrokenDependencies(t *testing.T) {
 
 	//
 	// Create a rule with a pair of dependencies
-	params["require"] = []ast.Object{
-		&ast.String{Value: "foo"},
-		&ast.String{Value: "bar"},
+	params["require"] = ast.Array{
+		Values: []ast.Object{
+			ast.String{Value: "foo"},
+			ast.String{Value: "bar"},
+		},
 	}
 
 	r2 := []ast.Node{
@@ -236,10 +238,11 @@ func TestIf(t *testing.T) {
 			Triggered:     false,
 			Params:        params,
 			ConditionType: "if",
-			Function: &ast.Funcall{
+			Function: ast.Funcall{
 				Name: "equal",
-				Args: []ast.Object{&ast.String{Value: "foo"},
-					&ast.String{Value: "bar"},
+				Args: []ast.Object{
+					ast.String{Value: "foo"},
+					ast.String{Value: "bar"},
 				},
 			},
 		},
@@ -283,10 +286,11 @@ func TestIf(t *testing.T) {
 	tmpt := r1[0].(*ast.Rule)
 	tmpt.Params = params
 	tmpt.ConditionType = "if"
-	tmpt.Function = &ast.Funcall{
+	tmpt.Function = ast.Funcall{
 		Name: "agrees",
-		Args: []ast.Object{&ast.String{Value: "foo"},
-			&ast.String{Value: "bar"},
+		Args: []ast.Object{
+			ast.String{Value: "foo"},
+			ast.String{Value: "bar"},
 		},
 	}
 
@@ -313,21 +317,21 @@ func TestTriggered(t *testing.T) {
 			Name:          "bob",
 			Triggered:     false,
 			ConditionType: "if",
-			Function: &ast.Funcall{
+			Function: ast.Funcall{
 				Name: "equal",
-				Args: []ast.Object{&ast.String{Value: "foo"},
-					&ast.String{Value: "bar"},
+				Args: []ast.Object{
+					ast.String{Value: "foo"},
+					ast.String{Value: "bar"},
 				},
 			},
 			Params: map[string]interface{}{
-				"require": "test",
+				"require": ast.String{Value: "test"},
 			},
 		},
 		&ast.Rule{Type: "file",
 			Name:      "test",
 			Triggered: true,
 			Params: map[string]interface{}{
-				"require": 3,
 				"target":  "/tmp/foo",
 				"ensure":  "present",
 				"content": "foo",
@@ -373,10 +377,11 @@ func TestUnless(t *testing.T) {
 			Triggered:     false,
 			Params:        params,
 			ConditionType: "unless",
-			Function: &ast.Funcall{
+			Function: ast.Funcall{
 				Name: "equal",
-				Args: []ast.Object{&ast.String{Value: "bar"},
-					&ast.String{Value: "bar"},
+				Args: []ast.Object{
+					ast.String{Value: "bar"},
+					ast.String{Value: "bar"},
 				},
 			},
 		},
@@ -418,10 +423,11 @@ func TestUnless(t *testing.T) {
 	//
 	// change params
 	tmpt := r1[0].(*ast.Rule)
-	tmpt.Function = &ast.Funcall{
+	tmpt.Function = ast.Funcall{
 		Name: "tervetulo",
-		Args: []ast.Object{&ast.String{Value: "foo"},
-			&ast.String{Value: "bar"},
+		Args: []ast.Object{
+			ast.String{Value: "foo"},
+			ast.String{Value: "bar"},
 		},
 	}
 

--- a/parser/fuzz_test.go
+++ b/parser/fuzz_test.go
@@ -56,6 +56,7 @@ func FuzzParser(f *testing.F) {
 		"you cannot assign an array to a variable",
 		"unterminated assignment",
 		"strconv.ParseInt: parsing",
+		"unexpected bare identifier",
 	}
 
 	f.Fuzz(func(t *testing.T, input []byte) {

--- a/parser/fuzz_test.go
+++ b/parser/fuzz_test.go
@@ -34,6 +34,13 @@ func FuzzParser(f *testing.F) {
 	f.Add([]byte(`shell { command => "uptime", if => equal(\"one\",\"two\"); } `))
 	f.Add([]byte(`shell { command => "uptime", unless => false(\"/bin/true\"); } `))
 
+	// Assignments
+	f.Add([]byte(`let a = "foo"`))
+	f.Add([]byte(`let a = true`))
+	f.Add([]byte(`let a = false;`))
+	f.Add([]byte(`let a = 32`))
+	f.Add([]byte(`let invalid =  [ "steve", "kemp"]`))
+
 	// Known errors are listed here.
 	//
 	// The purpose of fuzzing is to find panics, or unexpected errors.
@@ -46,9 +53,9 @@ func FuzzParser(f *testing.F) {
 		"assignment can only be made to identifiers",
 		"illegal token",
 		"end of file",
+		"you cannot assign an array to a variable",
 		"unterminated assignment",
 		"strconv.ParseInt: parsing",
-		"TODO: Implement",
 	}
 
 	f.Fuzz(func(t *testing.T, input []byte) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -227,16 +227,15 @@ func (p *Parser) parseInclude() (*ast.Include, error) {
 	// The include statement we'll return
 	inc := &ast.Include{}
 
-	// Get the thing we should include.
-	t := p.nextToken()
-
-	// We only allow strings to be used for inclusion.
-	if t.Type != token.STRING {
-		return inc, fmt.Errorf("only strings are supported for include statements; got %v", t)
+	// Parse the thing we should include.
+	tok := p.nextToken()
+	obj, err := p.parsePrimitive(tok)
+	if err != nil {
+		return inc, err
 	}
 
-	// The include-command
-	inc.Source = t.Literal
+	// Save the thing away
+	inc.Source = obj
 
 	// Look at the next token and see if it is a
 	// conditional inclusion

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -179,11 +179,16 @@ func (p *Parser) parseLet() (*ast.Assign, error) {
 
 	// Parse it
 	val, err := p.parsePrimitive(t)
-
-	// Error-checking.
 	if err != nil {
 		return let, err
 	}
+
+	// Assignments won't handle arrays yet
+	_, ok := val.(ast.Array)
+	if ok {
+		return let, fmt.Errorf("you cannot assign an array to a variable")
+	}
+
 	let.Value = val
 
 	// Look at the next token and see if it is a
@@ -370,8 +375,8 @@ func (p *Parser) parseBlock(ty string) (*ast.Rule, error) {
 		//   "if|unless" =>  FOO ( arg1, arg2 .. )
 		if name == "if" || name == "unless" {
 
-			// Parse the function
 			tok := p.nextToken()
+
 			action, err := p.parsePrimitive(tok)
 
 			if err != nil {
@@ -381,7 +386,7 @@ func (p *Parser) parseBlock(ty string) (*ast.Rule, error) {
 			// Confirm the action is a Funcall
 			faction, ok := action.(ast.Funcall)
 			if !ok {
-				return r, fmt.Errorf("expected function-call after %s, got %v", next, action)
+				return r, fmt.Errorf("expected function-call after '%s', got %v", name, action)
 			}
 
 			// Otherwise save the condition.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -513,8 +513,19 @@ func (p *Parser) parsePrimitive(tok token.Token) (ast.Object, error) {
 
 		}
 
+		// Here we have a bare identifier.
+		//
+		// We could allow this:
+		//
+		//    let a = "Steve"
+		//    log { message => a }
+		//
+		// However at the moment we do not.
+		//
+		return nil, fmt.Errorf("unexpected bare identifier %s", name)
+
 	case token.LSQUARE:
-		vals, err := p.parseMultiplePrimitives()
+		vals, err := p.parseArrayofPrimitives()
 		if err != nil {
 			return nil, err
 		}
@@ -535,7 +546,7 @@ func (p *Parser) parsePrimitive(tok token.Token) (ast.Object, error) {
 	return nil, fmt.Errorf("unexpected type parsing primitive:%v", tok)
 }
 
-// parseMultiplePrimitives attempts to parse multiple values within a
+// parseArrayofPrimitives attempts to parse multiple values within a
 // "[" + "]" separated block.
 //
 // Because we quit when we find "]" and we ignore "[" we cannot parse
@@ -547,7 +558,7 @@ func (p *Parser) parsePrimitive(tok token.Token) (ast.Object, error) {
 //
 //     [ "This", [ "Is", "Wrong" ] ]
 //
-func (p *Parser) parseMultiplePrimitives() ([]ast.Object, error) {
+func (p *Parser) parseArrayofPrimitives() ([]ast.Object, error) {
 
 	var ret []ast.Object
 	var val ast.Object

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -203,7 +203,7 @@ func (p *Parser) parseLet() (*ast.Assign, error) {
 		}
 
 		// Confirm the action is a Funcall
-		faction, ok := action.(*ast.Funcall)
+		faction, ok := action.(ast.Funcall)
 		if !ok {
 			return let, fmt.Errorf("expected function-call after %s, got %v", nxt, action)
 		}
@@ -250,7 +250,7 @@ func (p *Parser) parseInclude() (*ast.Include, error) {
 		}
 
 		// Confirm the action is a Funcall
-		faction, ok := action.(*ast.Funcall)
+		faction, ok := action.(ast.Funcall)
 		if !ok {
 			return inc, fmt.Errorf("expected function-call after %s, got %v", nxt, action)
 		}
@@ -379,7 +379,7 @@ func (p *Parser) parseBlock(ty string) (*ast.Rule, error) {
 			}
 
 			// Confirm the action is a Funcall
-			faction, ok := action.(*ast.Funcall)
+			faction, ok := action.(ast.Funcall)
 			if !ok {
 				return r, fmt.Errorf("expected function-call after %s, got %v", next, action)
 			}
@@ -398,8 +398,8 @@ func (p *Parser) parseBlock(ty string) (*ast.Rule, error) {
 		// We need to find the value, which is either a single
 		// object, or an array of objects.
 		//
-        // parsePrimitive will handle both cases.
-        //
+		// parsePrimitive will handle both cases.
+		//
 		next = p.nextToken()
 		value, err := p.parsePrimitive(next)
 		if err != nil {
@@ -426,14 +426,14 @@ func (p *Parser) getName(params map[string]interface{}) string {
 	if ok {
 
 		// OK we did.  Was it a string?
-		str, ok := n.(*ast.String)
+		str, ok := n.(ast.String)
 		if ok {
 			return str.Value
 		}
 
 		// Show a warning.
 		if p.debug {
-			fmt.Printf("WARNING: Name of rule is not *ast.String, got %T\n", n)
+			fmt.Printf("WARNING: Name of rule is not ast.String, got %T\n", n)
 		}
 	}
 
@@ -464,13 +464,13 @@ func (p *Parser) parsePrimitive(tok token.Token) (ast.Object, error) {
 	switch tok.Type {
 
 	case token.BACKTICK:
-		return &ast.Backtick{Value: tok.Literal}, nil
+		return ast.Backtick{Value: tok.Literal}, nil
 
 	case token.BOOLEAN:
 		if tok.Literal == "true" {
-			return &ast.Boolean{Value: true}, nil
+			return ast.Boolean{Value: true}, nil
 		}
-		return &ast.Boolean{Value: false}, nil
+		return ast.Boolean{Value: false}, nil
 
 	case token.IDENT:
 		// if this is an identifier and the next token is "("
@@ -505,7 +505,7 @@ func (p *Parser) parsePrimitive(tok token.Token) (ast.Object, error) {
 				return nil, fmt.Errorf("unexpected EOF in function-call")
 			}
 
-			return &ast.Funcall{Name: name, Args: args}, nil
+			return ast.Funcall{Name: name, Args: args}, nil
 
 		}
 
@@ -515,17 +515,17 @@ func (p *Parser) parsePrimitive(tok token.Token) (ast.Object, error) {
 			return nil, err
 		}
 
-		return &ast.Array{Values: vals}, nil
+		return ast.Array{Values: vals}, nil
 
 	case token.NUMBER:
 		val, err := strconv.ParseInt(tok.Literal, 0, 64)
 		if err != nil {
 			return nil, err
 		}
-		return &ast.Number{Value: val}, nil
+		return ast.Number{Value: val}, nil
 
 	case token.STRING:
-		return &ast.String{Value: tok.Literal}, nil
+		return ast.String{Value: tok.Literal}, nil
 
 	}
 	return nil, fmt.Errorf("unexpected type parsing primitive:%v", tok)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -226,7 +226,7 @@ func TestInclude(t *testing.T) {
 	// Broken statements
 	broken := []string{
 		"include",
-		"include `/bin/ls`",
+		"include 22.2",
 		"include \"test.inc\" unless false(/bin/ls",
 		"include \"test.inc\" unless false(/bin/ls,",
 		"include \"test.inc\" if true(/bin/ls,",
@@ -250,6 +250,7 @@ func TestInclude(t *testing.T) {
 	// Now test valid includes
 	valid := []string{
 		"include \"test.inc\"",
+		"include [ \"test.inc\", \"test.inc\"] ",
 		"include \"test.inc\" unless failure(\"/bin/ls\")",
 		"include \"test.inc\" if success(\"/bin/ls\")",
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -163,7 +163,7 @@ func TestConditionalErrors(t *testing.T) {
 		{Input: `shell { name => "OK4",
                                  command => "echo Comparison Worked!",
                                  unless => foo foo`,
-			Error: "unexpected type parsing primitive"},
+			Error: "unexpected bare identifier foo"},
 	}
 
 	for _, test := range broken {


### PR DESCRIPTION
This pull-request introduces a new primitive object-type; Array.

Using this the parser was simplified, such that we make no distinction in the types that we parse.

As modules receive `[]string` parameters there is no significant change at runtime:

* The parser parses the input program into strings, numbers, booleans, etc, and now arrays.
* The executor will differentiate between arrays and single-values.
  * This handles parameters appropriately, expanding before passing to the modules that run changes.

Unfortunately arrays are always going to be a special case - every other simple-object has an "Evaluate" method which retrieves the value. But evaluating an array is a weird one - what should it return?  Currently I return a string which is joined of the evaluated contents of the array contents.

Despite the minor caveat I think that this change is useful, because it means that we're using "ast.Object" everywhere - not sometimes using "ast.Object" and sometimes "[]ast.Object".

I removed the pointer-receivers, and used concrete objects rather than pointers to them, to simplify the operation too.  But that's a minor implementation detail.

TLDR; Parsing arrays is now permitted more generally, and objects are handled more consistently.