### PR TITLE
Allow our lexer to parse negative numbers

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
+        with:
+          args: --timeout 5m0s
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull-request updates our lexer to allow parsing (integer)
numbers which contain a `+` or `-` prefix.  For example this
allows parsing:

     rand( -100, +100 )

This closes #117.