### PR TITLE
Allow sudo for adding/removing packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 * [Github Setup](#github-setup)
 
 
+
+
 # marionette
 
 `marionette` is a simple command-line application which is designed to carry out system automation tasks.  It was designed to resemble the well-known configuration-management application [puppet](https://puppet.com/), albeit in a much simpler and more minimal manner.
@@ -103,6 +105,10 @@ A rule may also contain an optional `triggered` attribute.  Rules which contain 
 Here is an example rule which executes a shell-command:
 
 ```
+
+
+
+
 # Run a command, unconditionally
 shell {
         command => "uptime > /tmp/uptime.txt"
@@ -129,6 +135,7 @@ There are four magical keys which can be supplied to all modules:
 | `notify` | This is used for [dependency management](#dependency-management) |
 | `if`     | This is used to make a rule [conditional](#conditionals)         |
 | `unless` | This is used to make a rule [conditional](#conditionals)         |
+
 
 
 ## Dependency Management
@@ -163,11 +170,22 @@ directory{ name   => "Create /tmp/blah",
 The alternative would have been to have the directory-creation trigger the shell-execution rule via an explicit notification:
 
 ```
+
+
+
+
 # This command will notify the "Test" rule, if it creates the directory
+
+
+
+
 # because it was not already present.
 directory{ target => "/tmp/blah",
            notify => "Test"
 }
+
+
+
 
 # Run the command, when triggered/notified.
 shell triggered { name         => "Test",
@@ -184,7 +202,6 @@ The difference in these two approaches is how often things run:
   * Because the directory-creation triggers the notification only when the rule changes (i.e. the directory goes from being "absent" to "present").
 
 You'll note that any rule which is followed by the token `triggered` will __only__ be executed when it is triggered by name.  If there is no `notify` key referring to that rule it will __never__ be executed.
-
 
 
 
@@ -242,9 +259,16 @@ More conditional primitives may be added if they appear to be necessary, or if u
 Conditionals may also be applied to variable assignments and file inclusion:
 
 ```
+
+
+
+
 # Include a file of rules, on a per-arch basis
 include "x86_64.rules" if equal( "${ARCH}","x86_64" )
 include "i386.rules"   if equal( "${ARCH}","i386" )
+
+
+
 
 # Setup a ${cmd} to download something, depending on what is present.
 let cmd = "curl --output ${dst} ${url}" if on_path("curl")
@@ -278,6 +302,7 @@ In addition to these conditional functions the following primitives are built in
   * Returns the SHA1-digest of the given value.
 * `upper(txt)`
   * Converts the given string to upper-case.
+
 
 
 ## Examples
@@ -332,6 +357,10 @@ file { name    => "set-todays-date",
 You can break large rule-files into pieces, and include them in each other:
 
 ```
+
+
+
+
 # main.in
 
 let prefix="/etc/marionette"
@@ -344,6 +373,10 @@ To simplify your recipe writing including other files may be made conditional,
 just like our rules:
 
 ```
+
+
+
+
 # main.in
 
 include "x86_64.rules" if equal( "${ARCH}","x86_64" )
@@ -371,7 +404,6 @@ There are additionally two "magic" variables available which will always have va
 | `${INCLUDE_FILE}` | The absolute path of the current file being processed.           |
 
 
-
 ### Outputs
 
 Some modules will set "outputs" after they've executed, and those outputs will be documented explicitly in the later list of available modules.
@@ -381,7 +413,15 @@ When a module creates an output it will be available for subsequent modules to u
 Here is an example showing the use of the `stdout` output which the [shell](#shell) module produces:
 
 ```
+
+
+
+
 # Run a command - This will produce "${user.stdout}" and "${user.stderr}"
+
+
+
+
 # variables which can be used later.
 shell {
            name => "user",
@@ -410,9 +450,11 @@ shell {
 
 
 
+
 # Module Types
 
 Our primitives are implemented in 100% pure golang, and are included with our binary, these are now described briefly:
+
 
 
 ## `directory`
@@ -491,6 +533,7 @@ edit { target  => "/etc/ssh/sshd_config",
 ```
 
 
+
 ## `fail`
 
 The fail-module is designed to terminate processing, if you find a situation where the local
@@ -549,6 +592,7 @@ Other valid parameters are:
 
 Where `template` is used, the template file is rendered using the
 [`text/template`](https://pkg.go.dev/text/template) Go package
+
 
 
 ## `git`
@@ -622,6 +666,7 @@ Valid parameters are:
 
 The `http` module is always regarded as having made a change on a successful request.
 
+
 ### `http` Outputs
 
 The following [outputs](#outputs) will be set:
@@ -676,11 +721,18 @@ The package-module allows you to install or remove a package from your system, v
 Example usage:
 
 ```
+
+
+
+
 # Install a single package
 package { name    => "Install bash",
           package => "bash",
           state   => "installed",
         }
+
+
+
 
 # Uninstall a series of packages
 package { package => [ "nano", "vim-tiny", "nvi" ],
@@ -689,6 +741,7 @@ package { package => [ "nano", "vim-tiny", "nvi" ],
 
 Valid parameters are:
 
+* `elevate` - Should contain the path to "sudo", or similar program to grant root-privileges.
 * `package` is a mandatory parameter, containing the package, or list of packages.
 * `state` - Should be one of `installed` or `absent`, depending upon whether you want to install or uninstall the named package(s).
 * `update` - If this is set to `true` then the system will be updated prior to installation.
@@ -731,6 +784,7 @@ To specify the query to run you should set one of the following two parameters:
 NOTE: You may find you need to append `multiStatements=true` to your DSN to ensure correct operation when reading SQL from a file.
 
 
+
 ## `shell`
 
 The shell module allows you to run shell-commands, complete with redirection and pipes.
@@ -766,6 +820,7 @@ shell { shell   => true,
       }
 ```
 
+
 ### `shell` Outputs
 
 The following [outputs](#outputs) will be set:
@@ -774,6 +829,7 @@ The following [outputs](#outputs) will be set:
   * Anything the command wrote to STDOUT.
 * `stderr`
   * Anything the command wrote to STDERR.
+
 
 
 ## `user`
@@ -793,10 +849,12 @@ user { login => "steve",
 
 
 
+
 # Future Plans
 
 * Gathering "facts" about the local system, and storing them as variables would be useful.
   * At the moment we just have a small number of [pre-declared variables](#pre-declared-variables).
+
 
 
 ## See Also
@@ -805,6 +863,7 @@ user { login => "steve",
   * This gives an overview of the structure.
 * There are some brief-notes on [fuzz-testing the parser](FUZZING.md).
   * This should ensure that there is no input that can crash our application.
+
 
 
 ## Github Setup

--- a/README.md
+++ b/README.md
@@ -633,6 +633,7 @@ group { group => "sysadmin",
         state => "present" }
 ```
 
+* `elevate` is an optional parameter, which should contain the path to "sudo", or similar program to grant root-privileges.
 * `group` is a mandatory parameter.
 * `state` should be one of `absent` or `present`, depending upon whether you want to add or remove the group.
 
@@ -741,7 +742,7 @@ package { package => [ "nano", "vim-tiny", "nvi" ],
 
 Valid parameters are:
 
-* `elevate` - Should contain the path to "sudo", or similar program to grant root-privileges.
+* `elevate` is an optional parameter, which should contain the path to "sudo", or similar program to grant root-privileges.
 * `package` is a mandatory parameter, containing the package, or list of packages.
 * `state` - Should be one of `installed` or `absent`, depending upon whether you want to install or uninstall the named package(s).
 * `update` - If this is set to `true` then the system will be updated prior to installation.
@@ -843,6 +844,7 @@ user { login => "steve",
        state => "present" }
 ```
 
+* `elevate` is an optional parameter, which should contain the path to "sudo", or similar program to grant root-privileges.
 * `login` is a mandatory parameter.
 * `shell` is an optional parameter to use for the users' shell.
 * `state` should be one of `absent` or `present`, depending upon whether you want to add or remove the user.

--- a/modules/module_group_unix.go
+++ b/modules/module_group_unix.go
@@ -30,7 +30,7 @@ func (g *GroupModule) Execute(args map[string]interface{}) (bool, error) {
 		if state == "absent" {
 
 			// remove the group
-			err := g.removeGroup(group)
+			err := g.removeGroup(args)
 			return true, err
 		}
 	}
@@ -69,6 +69,12 @@ func (g *GroupModule) createGroup(args map[string]interface{}) error {
 	// The creation command
 	cmdArgs := []string{"groupadd", group}
 
+	// do we need to enhance our permissions?
+	privs := StringParam(args, "elevate")
+	if privs != "" {
+		cmdArgs = append([]string{privs}, cmdArgs...)
+	}
+
 	// Show what we're doing
 	log.Printf("[DEBUG] Running %s", cmdArgs)
 
@@ -93,10 +99,18 @@ func (g *GroupModule) createGroup(args map[string]interface{}) error {
 }
 
 // removeGroup removes the local group
-func (g *GroupModule) removeGroup(group string) error {
+func (g *GroupModule) removeGroup(args map[string]interface{}) error {
+
+	group := StringParam(args, "group")
 
 	// The removal command
 	cmdArgs := []string{"groupdel", group}
+
+	// do we need to enhance our permissions?
+	privs := StringParam(args, "elevate")
+	if privs != "" {
+		cmdArgs = append([]string{privs}, cmdArgs...)
+	}
 
 	// Show what we're doing
 	log.Printf("[DEBUG] Running %s", cmdArgs)

--- a/modules/module_package.go
+++ b/modules/module_package.go
@@ -81,6 +81,12 @@ func (pm *PackageModule) Execute(args map[string]interface{}) (bool, error) {
 	// Package abstraction
 	pkg := system.New()
 
+	// Do we need to use doas/sudo?
+	privs := StringParam(args, "elevate")
+	if privs != "" {
+		pkg.UsePrivilegeHelper(privs)
+	}
+
 	// Get the packages we're working with
 	packages := pm.getPackages(args)
 

--- a/modules/module_user_unix.go
+++ b/modules/module_user_unix.go
@@ -30,7 +30,7 @@ func (g *UserModule) Execute(args map[string]interface{}) (bool, error) {
 		if state == "absent" {
 
 			// remove the user
-			err := g.removeUser(login)
+			err := g.removeUser(args)
 			return true, err
 		}
 	}
@@ -77,6 +77,12 @@ func (g *UserModule) createUser(args map[string]interface{}) error {
 	// The user-creation command
 	cmdArgs := []string{"useradd", "--shell", shell, login}
 
+	// do we need to enhance our permissions?
+	privs := StringParam(args, "elevate")
+	if privs != "" {
+		cmdArgs = append([]string{privs}, cmdArgs...)
+	}
+
 	// Show what we're doing
 	log.Printf("[DEBUG] Running %s", cmdArgs)
 
@@ -101,10 +107,18 @@ func (g *UserModule) createUser(args map[string]interface{}) error {
 }
 
 // removeUser removes the local user
-func (g *UserModule) removeUser(login string) error {
+func (g *UserModule) removeUser(args map[string]interface{}) error {
+
+	login := StringParam(args, "login")
 
 	// The user-removal command
 	cmdArgs := []string{"userdel", login}
+
+	// do we need to enhance our permissions?
+	privs := StringParam(args, "elevate")
+	if privs != "" {
+		cmdArgs = append([]string{privs}, cmdArgs...)
+	}
 
 	// Show what we're doing
 	log.Printf("[DEBUG] Running %s", cmdArgs)


### PR DESCRIPTION
This pull-request, once complete, will allow a new "elevate" parameter to be used for gaining permissions to run some operations.

Initially this will cover adding/removing packages, and later we'll add support for use in adding/removing users and groups.

* [x] support the use of `elevate` for package operations.
* [x] support the use of `elevate` for user operations.
* [x] support the use of `elevate` for group operations.

Once complete, and merged, this will close #123.