### PR TITLE
package: allow passing of env vars to pkg cmd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/docker/distribution v2.8.0+incompatible // indirect
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/go-sql-driver/mysql v1.6.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -473,6 +473,8 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
fixes #128 

  - allow passing environment variables to package commands
    - env vars need to be configured without spaces around the = symbol
  - for systems with debian packages pass the following
    - `DEBIAN_FRONTEND=noninteractive`
    - `NEEDRESTART_MODE=a`
    - this prevents `apt` from hanging waiting for user input

`apt` sometimes requires user input (`debconf`, `needrestart` being the most common). this is fixed by setting `dpkg` to use `noninteractive` mode and setting `needrestart` to use `auto` mode. this is done via environment variables.

therefore, allow the package command to use the `Env` slice to `os.exec` and configure on a package command basis (`apt`, `yum`, etc) setting of the necessary environment variables.