### PR TITLE
add functions to compare the last modification time of two files

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,10 @@ In addition to these conditional functions the following primitives are built in
   * Returns the SHA1-digest of the given value.
 * `upper(txt)`
   * Converts the given string to upper-case.
+* `newer(file1, file2)`
+  * Returns true if file1 has a newer modification time than file2.
+* `older(file1, file2)`
+  * Returns true if file1 has an older modification time than file2.
 
 
 


### PR DESCRIPTION
  fixes #131

  - add two functions to compare file modification times, newer and older. compares mtime of first compared to second
  - return error if either file doesn't exist, so check the files exist first!
  - since the functions need existing files to compare in the test code we need to be able to skip the arg test for these functions in the arg only test and check the arg limits in the comprehensive tests